### PR TITLE
corrected the virtual host provider properties to match new format

### DIFF
--- a/jobs/service-fabrik-broker/spec
+++ b/jobs/service-fabrik-broker/spec
@@ -65,6 +65,7 @@ provides:
   - backup.backup_restore_status_check_every
   - backup.abort_time_out
   - backup.provider
+  - virtual_host.provider
   - docker.url
   - docker.skip_ssl_validation
   - docker.allocate_docker_host_ports
@@ -208,7 +209,7 @@ properties:
   backup.status_check_every:
     description: "Interval in milliseconds to check the status of service fabrik backup"
     default: 120000
-  broker.virtual_host.provider:
+  virtual_host.provider:
     description: "IaaS-specific virtual host manager provider configuration"
 
   cf.url:

--- a/jobs/service-fabrik-broker/templates/config/settings.yml.erb
+++ b/jobs/service-fabrik-broker/templates/config/settings.yml.erb
@@ -200,7 +200,7 @@ production:
   # VIRTUAL HOST MANAGER SETTINGS #
   #################################
   virtual_host:
-    provider: <%= JSON.dump(p('broker.virtual_host.provider', nil)) %>
+    provider: <%= JSON.dump(p('virtual_host.provider', nil)) %>
 
   #########################
   # CLOUDFOUNDRY SETTINGS #


### PR DESCRIPTION
Issue: https://github.com/cloudfoundry-incubator/service-fabrik-boshrelease/issues/30
Raising this new PR to correct the [PR](https://github.com/cloudfoundry-incubator/service-fabrik-boshrelease/pull/29), adding new format in which properties are expected to be given in jobs spec, changed according to BOSH V2 changes. 
This is tested in SC6 landscape with the latest code changes.