### PR TITLE
Fix/blueprint manifest template

### DIFF
--- a/services/blueprint-manifest.yml.ejs
+++ b/services/blueprint-manifest.yml.ejs
@@ -1,4 +1,4 @@
-<%= spec.header.select({disk_pools: [p('disk_pool')], resource_pools: [p('resource_pool')]}) %>
+<%= spec.header %>
 
 update:
   canaries: 0
@@ -7,23 +7,19 @@ update:
   update_watch_time: 1000-100000
   serial: false
 
-jobs: &jobs
+instance_groups: &instance_groups
 <%
-const net = spec.networks[0];
+var net;
+var azs;
+if (spec.multi_az_enabled){
+  net = spec.networks[1];
+  azs = '[z1, z2]';
+} else {
+  net = spec.networks[0];
+  azs = '[z1]';
+}
+const stemcell = spec.stemcell;
 const members = net.static.slice(0,1);
-%>
-- name: blueprint_<%= net.az %>
-  instances: <%= members.length %>
-  networks:
-  - name: <%= net.name %>
-    static_ips: <%= JSON.stringify(members) %>
-  resource_pool: <%= `${p('resource_pool')}_${net.az}` %>
-  persistent_disk_pool: <%= p('disk_pool') %>
-  templates:
-  - { name: blueprint, release: blueprint }
-  - { name: blueprint-agent, release: blueprint }
-
-<%
 const properties = {};
 if (!spec.previous_manifest) {
   /* create scenario: pick random service instance properties */
@@ -34,21 +30,37 @@ if (!spec.previous_manifest) {
     }
   };
 } else {
-  /* update scenario: preserve previous service instance properties */
-  properties.blueprint = spec.previous_manifest.properties.blueprint;
+  if(!spec.previous_manifest.instance_groups){
+    properties.blueprint = spec.previous_manifest.properties.blueprint;
+  }else{
+    properties.blueprint = spec.previous_manifest.instance_groups[0].jobs[0].properties;
+  }
 }
 %>
-properties:
-  blueprint: &blueprint
-    port: 8080
-    admin:
-      username: <%= properties.blueprint.admin.username %>
-      password: <%= properties.blueprint.admin.password %>
-  agent:
-    username: <%= p('agent.auth.username') %>
-    password: <%= p('agent.auth.password') %>
-    provider: <%= JSON.stringify(p('agent.provider')) %>
-    manifest:
-      jobs: *jobs
-      properties:
-        blueprint: *blueprint
+- name: blueprint
+  migrated_from: 
+  - name: blueprint_z1
+    az: z1
+  instances: <%= members.length %>
+  networks:
+  - name: <%= net.name %>
+    static_ips: <%= JSON.stringify(members) %>
+  vm_type: <%= p('vm_type') %>
+  persistent_disk_type: <%= p('disk_type') %>
+  azs: <%= azs %>
+  stemcell: <%= stemcell.alias %>
+  jobs:
+  - name: blueprint
+    release: blueprint
+    blueprint: &blueprint
+    properties:
+      port: 8080
+      admin:
+        username: <%= properties.blueprint.admin.username %>
+        password: <%= properties.blueprint.admin.password %>
+  - name: broker-agent
+    release: blueprint
+    properties:
+      username: <%= p('agent.auth.username') %>
+      password: <%= p('agent.auth.password') %>
+      provider: <%= JSON.stringify(p('agent.provider')) %>

--- a/services/blueprint.yml.erb
+++ b/services/blueprint.yml.erb
@@ -118,8 +118,8 @@ plans:
       - { name: blueprint, version: 1.0.0, git: "https://github.com/sap/service-fabrik-blueprint-boshrelease.git" }
       context:
         agent: *agent
-        resource_pool: micro
-        disk_pool: hdd_1gb
+        vm_type: service_fabrik_vm_micro
+        disk_type: service_fabrik_hdd_1gb
   description: 'Blueprint 1.0 service x-small (managed service in beta)'
   metadata:
     costs:
@@ -144,8 +144,8 @@ plans:
       releases: *dedicated_releases
       context:
         agent: *agent
-        resource_pool: micro
-        disk_pool: hdd_2gb
+        vm_type: service_fabrik_vm_micro
+        disk_type: service_fabrik_hdd_2gb
   description: 'Blueprint 1.0 service large (managed service in beta)'
   metadata:
     costs:

--- a/services/blueprint.yml.erb
+++ b/services/blueprint.yml.erb
@@ -115,7 +115,7 @@ plans:
       template: <%= base64_template('blueprint-manifest') %>
       dashboard_template: <%= base64_template('blueprint-dashboard') %>
       releases: &dedicated_releases
-      - { name: blueprint, version: 1.0.0, git: "https://github.com/sap/service-fabrik-blueprint-boshrelease.git" }
+      - { name: blueprint, version: 1.7.0, git: "https://github.com/sap/service-fabrik-blueprint-boshrelease.git" }
       context:
         agent: *agent
         vm_type: service_fabrik_vm_micro

--- a/templates/deployment.yml
+++ b/templates/deployment.yml
@@ -112,14 +112,14 @@ instance_groups:
             reuse_compilation_vms: true
             workers: 4
           networks:
-          - name: service-fabrik-bosh-services
+          - name: sf_bosh_services
             subnets: default
             type: manual
           - name: compilation
             type: dynamic
           segmentation:
             capacity: -1
-            network_name: service-fabrik-bosh-services
+            network_name: sf_bosh_services
             offset: 1
             size: 8
           stemcell:

--- a/templates/deployment.yml
+++ b/templates/deployment.yml
@@ -200,6 +200,12 @@ instance_groups:
       process_every: 3 minutes
   - name: service-fabrik-report
     release: service-fabrik
+    properties:
+      report:
+        ip: default
+        ssl:
+          cert: ((ssl.cert))
+          key: ((ssl.key))
   - name: swarm_manager
     release: service-fabrik
     properties:

--- a/templates/ops-file-aws.yml
+++ b/templates/ops-file-aws.yml
@@ -62,10 +62,6 @@
   value: https://10.11.252.10:2376
 
 - type: replace
-  path: /instance_groups/name=broker/jobs/name=service-fabrik-broker/properties/directors/name=bootstrap-bosh/url
-  value: https://10.0.3.12:25555
-
-- type: replace
   path: /instance_groups/name=broker/jobs/name=service-fabrik-broker/properties/directors/name=bosh/url
   value: https://10.0.3.11:25555
 

--- a/templates/ops-file.yml
+++ b/templates/ops-file.yml
@@ -40,14 +40,6 @@
   value: admin
 
 - type: replace
-  path: /instance_groups/name=broker/jobs/name=service-fabrik-broker/properties/directors/name=bootstrap-bosh/password
-  value: admin
-
-- type: replace
-  path: /instance_groups/name=broker/jobs/name=service-fabrik-broker/properties/directors/name=bootstrap-bosh/username
-  value: admin
-
-- type: replace
   path: /instance_groups/name=broker/jobs/name=service-fabrik-broker/properties/directors/name=bosh/username
   value: admin
 


### PR DESCRIPTION
Fixes #55 : Blueprint manifest template needs to be updated

* Modifying the blueprint manifest template as boshv2 manifest

* Modifying the vm and disk type, network type for blueprint manifest

* Bumping the blueprint version to 1.7.0