### PR TITLE
Fix/docker demon

### DIFF
--- a/jobs/docker/spec
+++ b/jobs/docker/spec
@@ -128,10 +128,6 @@ properties:
     description: "directory on which NFS volume is mounted on docker node"
     default: "/var/vcap/store"  
 
-  docker.daemon.old.keyfile:
-    description: "old location where docker keeps its key file"
-    default: "/etc/docker/key.json"
-
   docker.daemon.keyfile:
     description: "location where docker keeps key file in persistence disk"
     default: "/var/vcap/store/docker/key.json"

--- a/jobs/docker/spec
+++ b/jobs/docker/spec
@@ -128,6 +128,15 @@ properties:
     description: "directory on which NFS volume is mounted on docker node"
     default: "/var/vcap/store"  
 
+  docker.daemon.old.keyfile:
+    description: "old location where docker keeps its key file"
+    default: "/etc/docker/key.json"
+
+  docker.daemon.keyfile:
+    description: "location where docker keeps key file in persistence disk"
+    default: "/var/vcap/store/docker/key.json"
+
+
   env.http_proxy:
     description: "HTTP proxy that Docker should use"
   env.https_proxy:

--- a/jobs/docker/templates/bin/docker_ctl.erb
+++ b/jobs/docker/templates/bin/docker_ctl.erb
@@ -87,6 +87,7 @@ case $1 in
         --group vcap \
         --data-root ${DOCKER_STORE_DIR}/docker \
         --host unix://${DOCKER_PID_DIR}/docker.sock \
+        ${DOCKER_DAEMON_KEY_FILE_ARG} \
         ${DOCKER_ICC} \
         ${DOCKER_INSECURE_REGISTRIES:-} \
         ${DOCKER_IP:-} \
@@ -136,6 +137,13 @@ case $1 in
     # Stop Docker daemon
     echo -n "Stopping docker daemon..."
     kill_and_wait ${DOCKER_PID_FILE}
+
+    # Move key.json if it exists in ephemeral disk to persistent disk
+    if [ -f ${DOCKER_DAEMON_OLD_KEY_FILE} ]
+    then
+       cp ${DOCKER_DAEMON_OLD_KEY_FILE} ${DOCKER_DAEMON_KEY_FILE}
+    fi
+
     set -e
     ;;
 

--- a/jobs/docker/templates/bin/docker_ctl.erb
+++ b/jobs/docker/templates/bin/docker_ctl.erb
@@ -137,13 +137,6 @@ case $1 in
     # Stop Docker daemon
     echo -n "Stopping docker daemon..."
     kill_and_wait ${DOCKER_PID_FILE}
-
-    # Move key.json if it exists in ephemeral disk to persistent disk
-    if [ -f ${DOCKER_DAEMON_OLD_KEY_FILE} ]
-    then
-       cp ${DOCKER_DAEMON_OLD_KEY_FILE} ${DOCKER_DAEMON_KEY_FILE}
-    fi
-
     set -e
     ;;
 

--- a/jobs/docker/templates/bin/job_properties.sh.erb
+++ b/jobs/docker/templates/bin/job_properties.sh.erb
@@ -182,6 +182,13 @@ export DOCKER_ULIMIT_NOFILE=<%= p('docker.ulimit.nofile') %>
 # NFS Mount path on docker node
 export DOCKER_VOLUME_MOUNTDIR=<%= p('docker.volume.mount_dir') %>
 
+# Default key file path docker daemon creates
+export DOCKER_DAEMON_OLD_KEY_FILE=<%= p('docker.daemon.old.keyfile') %>
+# Docker daemon key file in persistence disk
+export DOCKER_DAEMON_KEY_FILE=<%= p('docker.daemon.keyfile') %>
+# key file location argument passed to docker daemon
+export DOCKER_DAEMON_KEY_FILE_ARG="--deprecated-key-path=<%= p('docker.daemon.keyfile') %>"
+
 # Proxy configuration
 <% if_p('env.http_proxy') do |http_proxy| %>
 export HTTP_PROXY="<%= http_proxy %>"

--- a/jobs/docker/templates/bin/job_properties.sh.erb
+++ b/jobs/docker/templates/bin/job_properties.sh.erb
@@ -182,10 +182,6 @@ export DOCKER_ULIMIT_NOFILE=<%= p('docker.ulimit.nofile') %>
 # NFS Mount path on docker node
 export DOCKER_VOLUME_MOUNTDIR=<%= p('docker.volume.mount_dir') %>
 
-# Default key file path docker daemon creates
-export DOCKER_DAEMON_OLD_KEY_FILE=<%= p('docker.daemon.old.keyfile') %>
-# Docker daemon key file in persistence disk
-export DOCKER_DAEMON_KEY_FILE=<%= p('docker.daemon.keyfile') %>
 # key file location argument passed to docker daemon
 export DOCKER_DAEMON_KEY_FILE_ARG="--deprecated-key-path=<%= p('docker.daemon.keyfile') %>"
 

--- a/jobs/swarm_manager/spec
+++ b/jobs/swarm_manager/spec
@@ -48,7 +48,7 @@ properties:
     default: "20s"
   swarm_manager.node_heartbeat_retries:
     description: "No of retries swarm manager makes to check if docker nodes is healthy again if it was un-healthy previously"
-    default: "30"
+    default: "60"
   swarm_manager.api_enable_cors:
     description: "Enable CORS headers in the remote API"
     default: false


### PR DESCRIPTION
Docker demon by default creates  key.json which also  docker demon ID in /etc/docker/ which is ephemeral disk and this file get lost in case of  stemcell change or docker node crash.

made changes to store the key.json in persistent disk as suggested in https://github.com/moby/moby/issues/36463

 and also increased the no of heartbeat retries from  30 to 60 times
