### PR TITLE
improve scheduler availability

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -42,3 +42,7 @@ node/node-v6.9.1-linux-x64.tar.xz:
   size: 9351072
   object_id: e79323b1-66d8-42a6-aba3-df4525ce82cd
   sha: 84b0b6fde43a4d892186119ba6b9f1db3c2c6129
+yaml2json/yaml2json:
+  size: 2349240
+  object_id: b3d57a81-3790-43a4-69eb-c2bcb02fcc54
+  sha: 8386a711bfc5f8dca5239f81277cb910ace5d7c2

--- a/jobs/service-fabrik-broker/spec
+++ b/jobs/service-fabrik-broker/spec
@@ -5,8 +5,11 @@ packages:
   - bosh-helpers
   - node
   - service-fabrik-broker
+  - jq
+  - yaml2json
 
 templates:
+  bin/drain.erb: bin/drain
   bin/service-fabrik-broker_ctl.erb: bin/service-fabrik-broker_ctl
   bin/job_properties.sh.erb: bin/job_properties.sh
   bin/health_check.erb: bin/health_check
@@ -28,6 +31,7 @@ provides:
   - enable_circuit_breaker
   - enable_swarm_manager
   - feature.ServiceInstanceAutoUpdate
+  - broker_drain_message
   - http_timeout
   - deployment_action_timeout
   - internal.port
@@ -137,6 +141,9 @@ properties:
   multi_az_enabled:
     description: "Switch used to turn on/off the multi-az support"
     default: false
+  broker_drain_message:
+    description: "Drain message that is updated into broker maintenance state. If undefined, then during drain maintenance state is not updated"
+    default: "BROKER_DRAIN_INITIATED"
 
   external.port:
     description: "Port used for external endpoints such as dashboards or the Service Fabrik API"

--- a/jobs/service-fabrik-broker/templates/bin/drain.erb
+++ b/jobs/service-fabrik-broker/templates/bin/drain.erb
@@ -14,7 +14,7 @@ if [[ $message != null ]] ; then
   if echo -e "$maintenance_status" | grep -E "true" > /dev/null ; then
     curl -skL -u "${current_broker_username}:${current_broker_password}" \
     -X PUT -H "Accept: application/json" "$broker_admin_target/service-fabrik/maintenance" \
-    -d "progress=$message"
+    -d "progress=$message" > /dev/null 2>&1
   fi
   echo 60 #sleep for 1 minute and let for batch jobs to go into maintenance gracefully
 fi

--- a/jobs/service-fabrik-broker/templates/bin/drain.erb
+++ b/jobs/service-fabrik-broker/templates/bin/drain.erb
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+# shellcheck disable=SC1091
+source /var/vcap/packages/bosh-helpers/ctl_setup.sh 'service-fabrik-broker' 'service-fabrik-broker' 'false'
+message="$("${YAML2JSON_CMD}" < "${SETTINGS_PATH}" | "${JQ_CMD}" -r ."${NODE_ENV}".broker_drain_message)"
+if [[ $message != null ]] ; then
+  current_broker_username="$("${YAML2JSON_CMD}" < "${SETTINGS_PATH}" | "${JQ_CMD}" -r ."${NODE_ENV}".username)"
+  current_broker_password="$("${YAML2JSON_CMD}" < "${SETTINGS_PATH}" | "${JQ_CMD}" -r ."${NODE_ENV}".password)"
+  admin_endpoint_host="$("${YAML2JSON_CMD}"  < "${SETTINGS_PATH}" | "${JQ_CMD}" -r ."${NODE_ENV}".internal.ip)"
+  admin_endpoint_port="$("${YAML2JSON_CMD}" < "${SETTINGS_PATH}" | "${JQ_CMD}" -r ."${NODE_ENV}".internal.port)"
+
+  broker_admin_target=https://${admin_endpoint_host}:${admin_endpoint_port}/admin
+  maintenance_status="$(curl -skL -u "${current_broker_username}:${current_broker_password}" "$broker_admin_target/service-fabrik/maintenance" 2> null)"
+  if echo -e "$maintenance_status" | grep -E "true" > /dev/null ; then
+    curl -skL -u "${current_broker_username}:${current_broker_password}" \
+    -X PUT -H "Accept: application/json" "$broker_admin_target/service-fabrik/maintenance" \
+    -d "progress=$message"
+  fi
+  echo 60 #sleep for 1 minute and let for batch jobs to go into maintenance gracefully
+fi
+exit 0

--- a/jobs/service-fabrik-broker/templates/bin/job_properties.sh.erb
+++ b/jobs/service-fabrik-broker/templates/bin/job_properties.sh.erb
@@ -16,6 +16,12 @@ export SETTINGS_PATH=$CONF_DIR/settings.yml
 # Node binary
 export NODE_CMD=/var/vcap/packages/node/bin/node
 
+#Yaml2json binary
+export YAML2JSON_CMD=/var/vcap/packages/yaml2json/bin/yaml2json
+
+#jq binary
+export JQ_CMD=/var/vcap/packages/jq/bin/jq
+
 # TLS enabled to contact swarm
 export DOCKER_TLS_VERIFY=1
 

--- a/jobs/service-fabrik-broker/templates/config/settings.yml.erb
+++ b/jobs/service-fabrik-broker/templates/config/settings.yml.erb
@@ -33,6 +33,7 @@ production:
   http_timeout: <%= p('http_timeout') %>
   deployment_action_timeout: <%= p('deployment_action_timeout') %>
   multi_az_enabled: <%= p('multi_az_enabled') %>
+  broker_drain_message: <%= p('broker_drain_message') %>
   ##############################
   # EXTERNAL ENDPOINT SETTINGS #
   ##############################

--- a/jobs/service-fabrik-broker/templates/config/settings.yml.erb
+++ b/jobs/service-fabrik-broker/templates/config/settings.yml.erb
@@ -110,6 +110,7 @@ production:
     agenda_collection: <%= link("scheduler").p('agenda_collection') %> # Name of the collection in mongodb which is to be used by agendaJS to store the scheduled job meta info
     maintenance_check_interval:  <%= link("scheduler").p('maintenance_check_interval') %>
     maintenance_mode_time_out:  <%= link("scheduler").p('maintenance_mode_time_out') %>
+    downtime_maintenance_phases: <%= link("scheduler").p('downtime_maintenance_phases') %>
     jobs:
       reschedule_delay: <%= link("scheduler").p('jobs.reschedule_delay') %>
       scheduled_backup:
@@ -146,10 +147,6 @@ production:
             - name : EventDetail
               retention_in_days: <%= link("scheduler").p('system_jobs.dbcollection_reaper.event_detail.retention_in_days') %>
         enabled: true
-      - name: 'MongoDB'
-        type: 'ServiceFabrikBackup'
-        interval: <%= p('mongodb.backup.schedule_interval') %>
-        enabled: false
 
   #######################
   # MONITORING SETTINGS #

--- a/jobs/service-fabrik-report/templates/config/settings.yml.erb
+++ b/jobs/service-fabrik-report/templates/config/settings.yml.erb
@@ -23,7 +23,7 @@ production:
   log_path: <%= log_path %>
   enable_circuit_breaker: <%= link("broker").p('enable_circuit_breaker') %>
   http_timeout: <%= link("broker").p('http_timeout') %>
-
+  broker_drain_message: <%= link("broker").p('broker_drain_message') %>
   ##############################
   # EXTERNAL ENDPOINT SETTINGS #
   ##############################

--- a/jobs/service-fabrik-report/templates/config/settings.yml.erb
+++ b/jobs/service-fabrik-report/templates/config/settings.yml.erb
@@ -141,11 +141,6 @@ production:
           - name : EventDetail
             retention_in_days: <%= link("scheduler").p('system_jobs.dbcollection_reaper.event_detail.retention_in_days') %>
       enabled: true
-    - name: 'MongoDB'
-      type: 'ServiceFabrikBackup'
-      interval: <%= link("broker").p('mongodb.backup.schedule_interval') %>
-      enabled: false
-
 
   ####################
   # MONGODB SETTINGS #

--- a/jobs/service-fabrik-scheduler/spec
+++ b/jobs/service-fabrik-scheduler/spec
@@ -29,6 +29,7 @@ provides:
   - default_lock_lifetime
   - maintenance_check_interval
   - maintenance_mode_time_out
+  - downtime_maintenance_phases
   - agenda_collection
   - jobs.reschedule_delay
   - jobs.scheduled_backup.max_attempts
@@ -83,6 +84,9 @@ properties:
   maintenance_mode_time_out:
     description: "(ms) - wait for sf deployment to complete. Beyond this timeout out time scheduler starts"
     default: 36000000
+  downtime_maintenance_phases:
+    description: "Maintenance phases during which (even any one of them) the scheduler must be shut down as ZDM is not in place across dependent components"
+    default: ['BROKER_DRAIN_INITIATED']
   agenda_collection:
     description: "Name of the collection in mongodb which is to be used by agendaJS to store the scheduled job meta info"
     default: "agendaJobs"

--- a/jobs/service-fabrik-scheduler/templates/config/settings.yml.erb
+++ b/jobs/service-fabrik-scheduler/templates/config/settings.yml.erb
@@ -110,6 +110,7 @@ production:
     agenda_collection: <%= p('agenda_collection') %> # Name of the collection in mongodb which is to be used by agendaJS to store the scheduled job meta info
     maintenance_check_interval:  <%= p('maintenance_check_interval') %>
     maintenance_mode_time_out:  <%= p('maintenance_mode_time_out') %>
+    downtime_maintenance_phases: <%= p('downtime_maintenance_phases') %>
     jobs:
       reschedule_delay: <%= p('jobs.reschedule_delay') %>
       scheduled_backup:
@@ -146,10 +147,6 @@ production:
             - name : EventDetail
               retention_in_days: <%= p('system_jobs.dbcollection_reaper.event_detail.retention_in_days') %>
         enabled: true
-      - name: 'MongoDB'
-        type: 'ServiceFabrikBackup'
-        interval: <%= link("broker").p('mongodb.backup.schedule_interval') %>
-        enabled: false
 
   #######################
   # MONITORING SETTINGS #

--- a/jobs/service-fabrik-scheduler/templates/config/settings.yml.erb
+++ b/jobs/service-fabrik-scheduler/templates/config/settings.yml.erb
@@ -33,6 +33,7 @@ production:
   feature:
     ServiceInstanceAutoUpdate: <%= link("broker").p('feature.ServiceInstanceAutoUpdate') %>
   multi_az_enabled: <%= link("broker").p('multi_az_enabled') %>
+  broker_drain_message: <%= link("broker").p('broker_drain_message') %>
   ##############################
   # EXTERNAL ENDPOINT SETTINGS #
   ##############################

--- a/packages/yaml2json/packaging
+++ b/packages/yaml2json/packaging
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+set -u
+
+yaml2jsonbinary=yaml2json/yaml2json
+
+if [[ -f $yaml2jsonbinary ]] ; then
+  echo "Binary: $yaml2jsonbinary found"
+else
+  echo "Binary: $yaml2jsonbinary not found"
+  exit 1
+fi
+
+chmod +x $yaml2jsonbinary
+mkdir -p "${BOSH_INSTALL_TARGET}"/bin/
+cp -a "$yaml2jsonbinary" "${BOSH_INSTALL_TARGET}"/bin

--- a/packages/yaml2json/spec
+++ b/packages/yaml2json/spec
@@ -1,0 +1,7 @@
+---
+name: yaml2json
+
+dependencies:
+
+files:
+  - yaml2json/yaml2json

--- a/src/bosh-helpers/ctl_setup.sh
+++ b/src/bosh-helpers/ctl_setup.sh
@@ -13,6 +13,7 @@ set -e # exit immediately if a simple command exits with a non-zero status
 
 export JOB_NAME=$1
 export OUTPUT_LABEL=${2:-$JOB_NAME}
+REDIRECT_STDOUT_STDERR=${3:-'true'}
 
 # Setup job home folder
 export HOME=/var/vcap
@@ -41,4 +42,6 @@ fi
 source $HOME/packages/bosh-helpers/ctl_utils.sh
 
 # Redirect output
-redirect_output ${OUTPUT_LABEL}
+if [[ $REDIRECT_STDOUT_STDERR == 'true' ]]; then
+  redirect_output ${OUTPUT_LABEL}
+fi


### PR DESCRIPTION
1. Drain script added in sf bosh release which will update the progress of maintenance window with the broker update status, which can be used by scheduler to then decide if it wants to go into maintenance immediately or wait till broker update has started.