### PR TITLE
Bug/swarm logs

### DIFF
--- a/jobs/docker/spec
+++ b/jobs/docker/spec
@@ -136,7 +136,6 @@ properties:
     description: "logs directory of docker"
     default: "/var/vcap/sys/log/docker"
 
-
   env.http_proxy:
     description: "HTTP proxy that Docker should use"
   env.https_proxy:

--- a/jobs/docker/spec
+++ b/jobs/docker/spec
@@ -132,6 +132,10 @@ properties:
     description: "location where docker keeps key file in persistence disk"
     default: "/var/vcap/store/docker/key.json"
 
+  docker.logs_dir:
+    description: "logs directory of docker"
+    default: "/var/vcap/sys/log/docker"
+
 
   env.http_proxy:
     description: "HTTP proxy that Docker should use"

--- a/jobs/docker/templates/config/syslog_forwarding.conf.erb
+++ b/jobs/docker/templates/config/syslog_forwarding.conf.erb
@@ -7,6 +7,7 @@ docker_name = p('docker.name')
 $ModLoad imfile
 
 #variables required for non-syslog log file forwarding – SystemErr
+$WorkDirectory /var/vcap/sys/log/docker
 $InputFileName /var/vcap/sys/log/docker/docker.stderr.log
 $InputFileTag <%= docker_name %>
 $InputFileStateFile <%= docker_name %>

--- a/jobs/docker/templates/config/syslog_forwarding.conf.erb
+++ b/jobs/docker/templates/config/syslog_forwarding.conf.erb
@@ -2,13 +2,14 @@
 network = spec.networks.methods(false).first
 ip = spec.networks.send(network).ip
 docker_name = p('docker.name')
+docker_logs_dir = p('docker.logs_dir')
 %>
 
 $ModLoad imfile
 
 #variables required for non-syslog log file forwarding – SystemErr
-$WorkDirectory /var/vcap/sys/log/docker
-$InputFileName /var/vcap/sys/log/docker/docker.stderr.log
+$WorkDirectory <%= docker_logs_dir %>
+$InputFileName <%= docker_logs_dir %>/docker.stderr.log
 $InputFileTag <%= docker_name %>
 $InputFileStateFile <%= docker_name %>
 $InputFileSeverity error

--- a/jobs/swarm_manager/spec
+++ b/jobs/swarm_manager/spec
@@ -55,6 +55,11 @@ properties:
   swarm_manager.overcommit:
     description: "Overcommit to apply on resources"
     default: "0.5"
+  swarm_manager.logs_dir:
+    description: "logs directory of swarm_manager"
+    default: "/var/vcap/sys/log/swarm_manager"
+
+
 
   swarm.discovery_options:
     description: "Swarm discovery options"

--- a/jobs/swarm_manager/spec
+++ b/jobs/swarm_manager/spec
@@ -59,8 +59,6 @@ properties:
     description: "logs directory of swarm_manager"
     default: "/var/vcap/sys/log/swarm_manager"
 
-
-
   swarm.discovery_options:
     description: "Swarm discovery options"
     default: []

--- a/jobs/swarm_manager/templates/config/syslog_forwarding.conf.erb
+++ b/jobs/swarm_manager/templates/config/syslog_forwarding.conf.erb
@@ -2,12 +2,13 @@
 network = spec.networks.methods(false).first
 ip = spec.networks.send(network).ip
 swarm_name= p('swarm.name')
+swarm_logs_dir=${LOG_DIR}
 %>
 
 $ModLoad imfile
 
 #variables required for non-syslog log file forwarding – SystemErr
-$WorkDirectory /var/vcap/sys/log/swarm_manager
+$WorkDirectory <%= swarm_logs_dir %>
 $InputFileName /var/vcap/sys/log/swarm_manager/swarm_manager.stderr.log
 $InputFileTag <%= swarm_name %>
 $InputFileStateFile <%= swarm_name %>

--- a/jobs/swarm_manager/templates/config/syslog_forwarding.conf.erb
+++ b/jobs/swarm_manager/templates/config/syslog_forwarding.conf.erb
@@ -7,9 +7,10 @@ swarm_name= p('swarm.name')
 $ModLoad imfile
 
 #variables required for non-syslog log file forwarding – SystemErr
+$WorkDirectory /var/vcap/sys/log/swarm_manager
 $InputFileName /var/vcap/sys/log/swarm_manager/swarm_manager.stderr.log
 $InputFileTag <%= swarm_name %>
-$InputFileStateFile <%= swarm_name %>
+$InputFileStateFile <%= swarm_name %>-monit
 $InputFileSeverity error
 $InputFileFacility local7
 $InputRunFileMonitor

--- a/jobs/swarm_manager/templates/config/syslog_forwarding.conf.erb
+++ b/jobs/swarm_manager/templates/config/syslog_forwarding.conf.erb
@@ -10,7 +10,7 @@ $ModLoad imfile
 $WorkDirectory /var/vcap/sys/log/swarm_manager
 $InputFileName /var/vcap/sys/log/swarm_manager/swarm_manager.stderr.log
 $InputFileTag <%= swarm_name %>
-$InputFileStateFile <%= swarm_name %>-monit
+$InputFileStateFile <%= swarm_name %>
 $InputFileSeverity error
 $InputFileFacility local7
 $InputRunFileMonitor

--- a/jobs/swarm_manager/templates/config/syslog_forwarding.conf.erb
+++ b/jobs/swarm_manager/templates/config/syslog_forwarding.conf.erb
@@ -2,14 +2,14 @@
 network = spec.networks.methods(false).first
 ip = spec.networks.send(network).ip
 swarm_name= p('swarm.name')
-swarm_logs_dir=${LOG_DIR}
+swarm_logs_dir=p('swarm_manager.logs_dir')
 %>
 
 $ModLoad imfile
 
 #variables required for non-syslog log file forwarding – SystemErr
 $WorkDirectory <%= swarm_logs_dir %>
-$InputFileName /var/vcap/sys/log/swarm_manager/swarm_manager.stderr.log
+$InputFileName <%= swarm_logs_dir %>/swarm_manager.stderr.log
 $InputFileTag <%= swarm_name %>
 $InputFileStateFile <%= swarm_name %>
 $InputFileSeverity error


### PR DESCRIPTION
For the imfile configuration if we dont specify the working directory sometimes it pushes the same logs again and again this can be reproduced by  restarting rsyslog

ex: /usr/sbin/service rsyslog restart

Added the working dir variable to the impfile and retested the scenario  by restarting the rsyslog and i see that same logs are not sent again.