### PR TITLE
Bug/unmount issue

### DIFF
--- a/jobs/docker/templates/bin/docker_ctl.erb
+++ b/jobs/docker/templates/bin/docker_ctl.erb
@@ -1,4 +1,3 @@
-
 #!/bin/bash
 
 set -e # exit immediately if a simple command exits with a non-zero status
@@ -128,8 +127,8 @@ case $1 in
     
     # Before stopping the docker deamon & containers block the demon port so that no further create
     # request are allowed/serviced during the stopping process, else if any create container request 
-    # is allowed in-between it will keep using the lvm volume that will keep the corresponding device 
-    # busy not allowing device to be unmounted during node update.
+    # is allowed in-between it will keep using the lvm volume which will keep the corresponding device 
+    # busy and not allowing device to be unmounted during node update.
     iptables -A INPUT -p tcp --dport ${DOCKER_TCP_PORT} -j DROP
 
     echo "Stopping docker containers..."

--- a/jobs/docker/templates/bin/docker_ctl.erb
+++ b/jobs/docker/templates/bin/docker_ctl.erb
@@ -1,3 +1,4 @@
+
 #!/bin/bash
 
 set -e # exit immediately if a simple command exits with a non-zero status
@@ -47,6 +48,11 @@ case $1 in
 
     # Set ulimits
     ulimit -n ${DOCKER_ULIMIT_NOFILE}
+
+    # Open up the docker demon port, remove any drop rule on the port
+    set +e
+    iptables -D INPUT -p tcp --dport ${DOCKER_TCP_PORT} -j DROP
+    set -e
 
     # Mount cgroupfs hierarchy
     ${JOB_DIR}/bin/cgroupfs-mount
@@ -119,6 +125,13 @@ case $1 in
   stop)
     set +e
     # Stop Docker containers
+    
+    # Before stopping the docker deamon & containers block the demon port so that no further create
+    # request are allowed/serviced during the stopping process, else if any create container request 
+    # is allowed in-between it will keep using the lvm volume that will keep the corresponding device 
+    # busy not allowing device to be unmounted during node update.
+    iptables -A INPUT -p tcp --dport ${DOCKER_TCP_PORT} -j DROP
+
     echo "Stopping docker containers..."
     containers="$(/var/vcap/packages/docker/bin/docker --host unix://${DOCKER_PID_DIR}/docker.sock ps -q)"
     if [[ ! -z $containers ]]; then
@@ -137,6 +150,9 @@ case $1 in
     # Stop Docker daemon
     echo -n "Stopping docker daemon..."
     kill_and_wait ${DOCKER_PID_FILE}
+
+    # Unblock the port docker demon port by removing the rule
+    iptables -D INPUT -p tcp --dport ${DOCKER_TCP_PORT} -j DROP
     set -e
     ;;
 

--- a/jobs/docker/templates/bin/job_properties.sh.erb
+++ b/jobs/docker/templates/bin/job_properties.sh.erb
@@ -26,6 +26,7 @@ export DOCKER_TMP_DIR=${TMP_DIR}
 <% if_p('docker.tcp_address', 'docker.tcp_port') do |address, port| %>
 # TCP Address/Port where Docker daemon will listen to
 export DOCKER_TCP="--host tcp://<%= address %>:<%= port %>"
+export DOCKER_TCP_PORT="<%= port %>"
 <% end %>
 
 # Set CORS headers in the remote API


### PR DESCRIPTION
during the shutting down of docker demon it stop all the running  docker containers. This process takes around 3-4 secounds.

In between the 3-4 seconds window of time if a new container creation request comes some times the container create request goes through and the container stays alive even if the docker demon dies which causes the disk drive not to get un-mount during node update as the new container is using it.

solution
--------
during the docker monit process shutdown blocking the docker demon linux port from listening any requests  which also blocks the create request and unblocking the linux port after demon was shutdown