### PR TITLE
Added missing prop service_addon_jobs

### DIFF
--- a/jobs/service-fabrik-broker/spec
+++ b/jobs/service-fabrik-broker/spec
@@ -98,6 +98,7 @@ provides:
   - quota
   - actions
   - services
+  - service_addon_jobs
   - directors
   - multi_az_enabled
 consumes:

--- a/jobs/service-fabrik-scheduler/templates/config/settings.yml.erb
+++ b/jobs/service-fabrik-scheduler/templates/config/settings.yml.erb
@@ -225,6 +225,7 @@ production:
       cert: <%= JSON.dump(link("broker").p('common.tls_client_cert')) %>
       key: <%= JSON.dump(link("broker").p('common.tls_client_key')) %>
 
+  service_addon_jobs: <%= link("broker").p('service_addon_jobs') %>
   #####################
   # DIRECTOR SETTINGS #
   #####################


### PR DESCRIPTION
The add on jobs that are added into a service manifest by service fabrik broker is configured via the param 'service_addon_jobs'. This property was defined from service fabrik broker which is why deployments post update does not show as outdated when checked via /admin outdated endpoint. However schedule update jobs in whose settings.yml this attrib is missing, it always removes addons from the regenerated manifest and thus BOSH reports them as change in manifest thus update jobs always finding these as outdated from schedule update jobs. Fix is simple, add the same param even in schedule update jobs settings.yml.