### PR TITLE
Removing the dependency on spec.bootstrap to fix the master ip for sf-broker

### DIFF
--- a/jobs/keepalived/templates/config/keepalived.conf.erb
+++ b/jobs/keepalived/templates/config/keepalived.conf.erb
@@ -9,7 +9,7 @@ vrrp_script chk_sfnode {
 vrrp_instance VI_1 {
     debug 2
     interface eth0 # interface to monitor
-    <% if ( spec.bootstrap === TRUE ) %>
+    <% if ( spec.ip == p('master_ip') ) %>
     state MASTER
     virtual_router_id 51 # Assign one ID for this route
     priority 101 # 101 on master, 100 on backup

--- a/jobs/keepalived/templates/config/keepalived.conf.erb
+++ b/jobs/keepalived/templates/config/keepalived.conf.erb
@@ -9,29 +9,20 @@ vrrp_script chk_sfnode {
 vrrp_instance VI_1 {
     debug 2
     interface eth0 # interface to monitor
+    virtual_router_id 51 # Assign one ID for this route
     <% if ( spec.ip == p('master_ip') ) %>
     state MASTER
-    virtual_router_id 51 # Assign one ID for this route
     priority 101 # 101 on master, 100 on backup
     unicast_src_ip <%= spec.ip %> # My IP
     unicast_peer {
-    <% if ( spec.ip == p('slave_ip') ) %>
-        <%= p('master_ip')  %> # peer IP
-    <% else %>
         <%= p('slave_ip')  %> # peer IP
-    <% end %>
     }
     <% else %>
     state BACKUP
-    virtual_router_id 51 # Assign one ID for this route
     priority 100 # 101 on master, 100 on backup
     unicast_src_ip <%= spec.ip %> # My IP
     unicast_peer {
-    <% if ( spec.ip == p('slave_ip') ) %>
         <%= p('master_ip')  %> # peer IP
-    <% else %>
-        <%= p('slave_ip')  %> # peer IP
-    <% end %>
     }
     <% end %>     
     track_script {


### PR DESCRIPTION
**Issue:**
Depending on the spec.bootstrap creates a situation in which 10.11.252.11 could be master initially (this ip being bootstrap) and sometimes, 10.11.252.12 could be the master initially (this ip being bootstrap). Thus, this brings in an indeterministic state in which we don't the master node/ip of the broker from outside the VM.
Here, initially refers to a fresh deployment (create) or update deployment of the broker. Here, by default, a node should be master and the other should be slave. Later on, the failover may change the setup.

**Fix:**
We expect the properties, `master_ip` and `slave_ip` to be passed from the sf-manifest. We should then rely on the values of these ips to decide if the VM should be master or slave initially.