### PR TITLE
Adding ssl property for external port

### DIFF
--- a/jobs/service-fabrik-broker/spec
+++ b/jobs/service-fabrik-broker/spec
@@ -40,6 +40,7 @@ provides:
   - internal.domain_socket.path
   - external.host
   - external.log_event
+  - external.ssl
   - external.api_requires_admin_scope
   - mongodb.url
   - mongodb.provision.plan_id
@@ -169,6 +170,8 @@ properties:
   external.log_event:
     description: "Determines whether event logging must be enabled or not"
     default: true
+  external.ssl:
+    description: "Private key used for external communication"
 
   internal.port:
     description: "Port used for internal endpoints such as administration or the service broker API"

--- a/jobs/service-fabrik-broker/templates/config/settings.yml.erb
+++ b/jobs/service-fabrik-broker/templates/config/settings.yml.erb
@@ -45,7 +45,12 @@ production:
     event_type: SF.API_EVENT
     trust_proxy: <%= external['trust_proxy'] %>
     port: <%= external['port'] %>
+    <% if_p('external.ssl') do |ssl| %>
     protocol: 'https'
+    ssl: <%= JSON.dump(ssl) %>
+    <% end.else do %>  
+    protocol: 'http'
+    <% end %>  
     host: <%= external['host'] %>
     cookie_secret: <%= external['cookie_secret'] %>
     cookie_secure: true

--- a/jobs/service-fabrik-broker/templates/config/settings.yml.erb
+++ b/jobs/service-fabrik-broker/templates/config/settings.yml.erb
@@ -49,7 +49,7 @@ production:
     protocol: 'https'
     ssl: <%= JSON.dump(ssl) %>
     <% end.else do %>  
-    protocol: 'http'
+    protocol: 'https'
     <% end %>  
     host: <%= external['host'] %>
     cookie_secret: <%= external['cookie_secret'] %>


### PR DESCRIPTION
* Requirement was to provide capability to optionally enable SSL for external port. 
* Therefore added new property in spec of service-fabrik-broker job and case where property not provided is handled in settings.yml.erb. 
* Tested with openssl client for both positive and negative testcases in broker VM of service-fabrik deployment on boshlite. 
* Also, used same SSL certificate as internal port for testing. 