### PR TITLE
added rules to block icmp & udp from sf services subnet

### DIFF
--- a/jobs/iptables-manager/templates/bin/iptables-manager_ctl.erb
+++ b/jobs/iptables-manager/templates/bin/iptables-manager_ctl.erb
@@ -21,6 +21,7 @@ exec 2>> $LOG_DIR/$JOB_NAME.stderr.log
 
 case $1 in
   start)
+    iptables -F #Flush all existing rules
     iptables -A INPUT -p ICMP --icmp-type 8 -s  "<%= p('allow_ips_list') %>" -j ACCEPT
     iptables -A INPUT -p udp -s "<%= p('allow_ips_list') %>" -j ACCEPT
     iptables -A INPUT -p tcp -s  "<%= p('allow_ips_list') %>" -j ACCEPT

--- a/jobs/iptables-manager/templates/bin/iptables-manager_ctl.erb
+++ b/jobs/iptables-manager/templates/bin/iptables-manager_ctl.erb
@@ -21,9 +21,12 @@ exec 2>> $LOG_DIR/$JOB_NAME.stderr.log
 
 case $1 in
   start)
-    iptables -F #Flush all existing rules
+    iptables -A INPUT -p ICMP --icmp-type 8 -s  "<%= p('allow_ips_list') %>" -j ACCEPT
+    iptables -A INPUT -p udp -s "<%= p('allow_ips_list') %>" -j ACCEPT
     iptables -A INPUT -p tcp -s  "<%= p('allow_ips_list') %>" -j ACCEPT
     <% if_p('block_ips_list') do |block_ips_list| %>
+    iptables -A INPUT -p ICMP --icmp-type 8 -s "<%= block_ips_list %>" -j  DROP
+    iptables -A INPUT -p udp -s "<%= block_ips_list %>" -j DROP
     iptables -A INPUT -p tcp -s  "<%= block_ips_list %>" -j DROP
     <% end %>
     echo 1 >> $PID_FILE

--- a/jobs/iptables-manager/templates/bin/iptables-manager_ctl.erb
+++ b/jobs/iptables-manager/templates/bin/iptables-manager_ctl.erb
@@ -22,11 +22,11 @@ exec 2>> $LOG_DIR/$JOB_NAME.stderr.log
 case $1 in
   start)
     iptables -F #Flush all existing rules
-    iptables -A INPUT -p ICMP --icmp-type 8 -s  "<%= p('allow_ips_list') %>" -j ACCEPT
+    iptables -A INPUT -p icmp --icmp-type 8 -s  "<%= p('allow_ips_list') %>" -j ACCEPT
     iptables -A INPUT -p udp -s "<%= p('allow_ips_list') %>" -j ACCEPT
     iptables -A INPUT -p tcp -s  "<%= p('allow_ips_list') %>" -j ACCEPT
     <% if_p('block_ips_list') do |block_ips_list| %>
-    iptables -A INPUT -p ICMP --icmp-type 8 -s "<%= block_ips_list %>" -j  DROP
+    iptables -A INPUT -p icmp --icmp-type 8 -s "<%= block_ips_list %>" -j  DROP
     iptables -A INPUT -p udp -s "<%= block_ips_list %>" -j DROP
     iptables -A INPUT -p tcp -s  "<%= block_ips_list %>" -j DROP
     <% end %>


### PR DESCRIPTION
ICMP (Ping) and UDP are blocked from other machines from the SF services subnet.