### PR TITLE
Revert "added rules to block icmp & udp from sf services subnet"

### DIFF
--- a/jobs/iptables-manager/templates/bin/iptables-manager_ctl.erb
+++ b/jobs/iptables-manager/templates/bin/iptables-manager_ctl.erb
@@ -22,12 +22,8 @@ exec 2>> $LOG_DIR/$JOB_NAME.stderr.log
 case $1 in
   start)
     iptables -F #Flush all existing rules
-    iptables -A INPUT -p icmp --icmp-type 8 -s  "<%= p('allow_ips_list') %>" -j ACCEPT
-    iptables -A INPUT -p udp -s "<%= p('allow_ips_list') %>" -j ACCEPT
     iptables -A INPUT -p tcp -s  "<%= p('allow_ips_list') %>" -j ACCEPT
     <% if_p('block_ips_list') do |block_ips_list| %>
-    iptables -A INPUT -p icmp --icmp-type 8 -s "<%= block_ips_list %>" -j  DROP
-    iptables -A INPUT -p udp -s "<%= block_ips_list %>" -j DROP
     iptables -A INPUT -p tcp -s  "<%= block_ips_list %>" -j DROP
     <% end %>
     echo 1 >> $PID_FILE


### PR DESCRIPTION
Reverts cloudfoundry-incubator/service-fabrik-boshrelease#96
Doing this as this is blocking outgoing internet traffic as well.