### PR TITLE
added credhub config to scheduler config

### DIFF
--- a/jobs/service-fabrik-scheduler/templates/config/settings.yml.erb
+++ b/jobs/service-fabrik-scheduler/templates/config/settings.yml.erb
@@ -220,6 +220,17 @@ production:
   etcd:
     url: <%= link("broker").p('etcd.url') %>
     ssl: <%= JSON.dump(link("broker").p('etcd.ssl')) %>
+  
+  #############################
+  # CREDHUB SETTINGS #
+  #############################
+  cred_provider:
+    credhub_url: <%= link("broker").p('cred_provider.credhub_url') %>
+    credhub_uaa_url: <%= link("broker").p('cred_provider.credhub_uaa_url') %>
+    credhub_client_id: <%= link("broker").p('cred_provider.credhub_client_id') %>
+    credhub_client_secret: <%= link("broker").p('cred_provider.credhub_client_secret') %>
+    credhub_username: <%= link("broker").p('cred_provider.credhub_username') %>
+    credhub_user_password: <%= link("broker").p('cred_provider.credhub_user_password') %>
 
   ###################
   # DOCKER SETTINGS #


### PR DESCRIPTION
Had missed adding credhub provider config, which is common set of attribs which is injected to each services. With this missing from scheduler config, it resulted in deployments being shown as outdated from update jobs even though they are not really outdated. 
This config ensures we dont fire unnecessary update requests, which results in no-operation in Bosh actually.