### PR TITLE
Updating godeps for iaas-utils

### DIFF
--- a/src/iaas-utils/Godeps/Godeps.json
+++ b/src/iaas-utils/Godeps/Godeps.json
@@ -1,0 +1,31 @@
+{
+	"ImportPath": "iaas-utils",
+	"GoVersion": "go1.10",
+	"GodepVersion": "v80",
+	"Deps": [
+		{
+			"ImportPath": "golang.org/x/net/context",
+			"Rev": "3673e40ba22529d22c3fd7c93e97b0ce50fa7bdd"
+		},
+		{
+			"ImportPath": "golang.org/x/net/context/ctxhttp",
+			"Rev": "3673e40ba22529d22c3fd7c93e97b0ce50fa7bdd"
+		},
+		{
+			"ImportPath": "golang.org/x/oauth2",
+			"Rev": "3d292e4d0cdc3a0113e6d207bb137145ef1de42f"
+		},
+		{
+			"ImportPath": "golang.org/x/oauth2/internal",
+			"Rev": "3d292e4d0cdc3a0113e6d207bb137145ef1de42f"
+		},
+		{
+			"ImportPath": "golang.org/x/oauth2/jws",
+			"Rev": "3d292e4d0cdc3a0113e6d207bb137145ef1de42f"
+		},
+		{
+			"ImportPath": "golang.org/x/oauth2/jwt",
+			"Rev": "3d292e4d0cdc3a0113e6d207bb137145ef1de42f"
+		}
+	]
+}

--- a/src/iaas-utils/Godeps/Readme
+++ b/src/iaas-utils/Godeps/Readme
@@ -1,0 +1,5 @@
+This directory tree is generated automatically by godep.
+
+Please do not edit.
+
+See https://github.com/tools/godep for more information.

--- a/src/iaas-utils/vendor/golang.org/x/oauth2/internal/token.go
+++ b/src/iaas-utils/vendor/golang.org/x/oauth2/internal/token.go
@@ -101,6 +101,7 @@ var brokenAuthHeaderProviders = []string{
 	"https://api.pushbullet.com/",
 	"https://api.soundcloud.com/",
 	"https://api.twitch.tv/",
+	"https://id.twitch.tv/",
 	"https://app.box.com/",
 	"https://connect.stripe.com/",
 	"https://login.mailchimp.com/",
@@ -128,6 +129,7 @@ var brokenAuthHeaderProviders = []string{
 	"https://log.finalsurge.com/oauth/token",
 	"https://multisport.todaysplan.com.au/rest/oauth/access_token",
 	"https://whats.todaysplan.com.au/rest/oauth/access_token",
+	"https://stackoverflow.com/oauth/access_token",
 }
 
 // brokenAuthHeaderDomains lists broken providers that issue dynamic endpoints.

--- a/src/iaas-utils/vendor/golang.org/x/oauth2/oauth2.go
+++ b/src/iaas-utils/vendor/golang.org/x/oauth2/oauth2.go
@@ -3,7 +3,8 @@
 // license that can be found in the LICENSE file.
 
 // Package oauth2 provides support for making
-// OAuth2 authorized and authenticated HTTP requests.
+// OAuth2 authorized and authenticated HTTP requests,
+// as specified in RFC 6749.
 // It can additionally grant authorization with Bearer JWT.
 package oauth2
 
@@ -123,6 +124,8 @@ func SetAuthURLParam(key, value string) AuthCodeOption {
 //
 // Opts may include AccessTypeOnline or AccessTypeOffline, as well
 // as ApprovalForce.
+// It can also be used to pass the PKCE challange.
+// See https://www.oauth.com/oauth2-servers/pkce/ for more info.
 func (c *Config) AuthCodeURL(state string, opts ...AuthCodeOption) string {
 	var buf bytes.Buffer
 	buf.WriteString(c.Endpoint.AuthURL)
@@ -185,13 +188,19 @@ func (c *Config) PasswordCredentialsToken(ctx context.Context, username, passwor
 //
 // The code will be in the *http.Request.FormValue("code"). Before
 // calling Exchange, be sure to validate FormValue("state").
-func (c *Config) Exchange(ctx context.Context, code string) (*Token, error) {
+//
+// Opts may include the PKCE verifier code if previously used in AuthCodeURL.
+// See https://www.oauth.com/oauth2-servers/pkce/ for more info.
+func (c *Config) Exchange(ctx context.Context, code string, opts ...AuthCodeOption) (*Token, error) {
 	v := url.Values{
 		"grant_type": {"authorization_code"},
 		"code":       {code},
 	}
 	if c.RedirectURL != "" {
 		v.Set("redirect_uri", c.RedirectURL)
+	}
+	for _, opt := range opts {
+		opt.setValue(v)
 	}
 	return retrieveToken(ctx, c, v)
 }

--- a/src/iaas-utils/vendor/golang.org/x/oauth2/transport.go
+++ b/src/iaas-utils/vendor/golang.org/x/oauth2/transport.go
@@ -31,9 +31,17 @@ type Transport struct {
 }
 
 // RoundTrip authorizes and authenticates the request with an
-// access token. If no token exists or token is expired,
-// tries to refresh/fetch a new token.
+// access token from Transport's Source.
 func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	reqBodyClosed := false
+	if req.Body != nil {
+		defer func() {
+			if !reqBodyClosed {
+				req.Body.Close()
+			}
+		}()
+	}
+
 	if t.Source == nil {
 		return nil, errors.New("oauth2: Transport's Source is nil")
 	}
@@ -46,6 +54,10 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	token.SetAuthHeader(req2)
 	t.setModReq(req, req2)
 	res, err := t.base().RoundTrip(req2)
+
+	// req.Body is assumed to have been closed by the base RoundTripper.
+	reqBodyClosed = true
+
 	if err != nil {
 		t.setModReq(req, nil)
 		return nil, err


### PR DESCRIPTION
Currently, we use the Godeps (https://github.com/tools/godep) to save the dependencies we require for IaasUtils (package/utility used for HA in GCP) in our boshrelease. As per Godeps, the source-code of the dependency is frozen and the commit-id of the dependency is stored in a file called, `Godeps.json`.

In our case, we felt we didn't need this `Godeps.json`, since the purpose of this file usually is to restore the dependency's code-base to the commit-id specified in the file in the `Gopath`. Since, we never pull the source-code, during our release deployment, we didn't check in the code.

However, we faced issues like, we didn't have any idea, which commit-id the dependency's code referred to. This info is required for getting approvals and/or maintaining the information about the version of the dependency (if a dependency doesn't have releases, this is the only way to track its version).

So, in this PR, we are adding the `Godeps.json` file. Since, it was missed earlier, we had to regenerate this file and in-process, the latest of the dependency was pulled. So, it is also showing some code changes in the codebase.