### PR TITLE
Adding configs for transaction logs delete time buffer

### DIFF
--- a/jobs/service-fabrik-backup-manager/templates/config/settings.yml.erb
+++ b/jobs/service-fabrik-backup-manager/templates/config/settings.yml.erb
@@ -105,6 +105,7 @@ production:
     num_of_allowed_restores: <%= link("broker").p('backup.num_of_allowed_restores') %>
     restore_history_days: <%= link("broker").p('backup.restore_history_days') %>
     reschedule_backup_delay_after_restore: <%= link("broker").p('backup.reschedule_backup_delay_after_restore') %>
+    transaction_logs_delete_buffer_time: <%= link("broker").p('backup.transaction_logs_delete_buffer_time') %>
     provider: <%= JSON.dump(link("broker").p('backup.provider', nil)) %>
 
   #################################

--- a/jobs/service-fabrik-broker/spec
+++ b/jobs/service-fabrik-broker/spec
@@ -86,6 +86,7 @@ provides:
   - backup.num_of_allowed_restores
   - backup.restore_history_days
   - backup.reschedule_backup_delay_after_restore
+  - backup.transaction_logs_delete_buffer_time
   - virtual_host.provider
   - docker.url
   - docker.skip_ssl_validation
@@ -289,6 +290,9 @@ properties:
   backup.reschedule_backup_delay_after_restore:
     description: "Delay to reschedule backup after restore in minutes"
     default: 3
+  backup.transaction_logs_delete_buffer_time:
+    description: "Delete transaction logs older than latest successful backup + this buffer time in minutes"
+    default: 30
   virtual_host.provider:
     description: "IaaS-specific virtual host manager provider configuration"
 

--- a/jobs/service-fabrik-broker/templates/config/settings.yml.erb
+++ b/jobs/service-fabrik-broker/templates/config/settings.yml.erb
@@ -225,6 +225,7 @@ production:
     num_of_allowed_restores: <%= p('backup.num_of_allowed_restores') %>
     restore_history_days: <%= p('backup.restore_history_days') %>
     reschedule_backup_delay_after_restore: <%= p('backup.reschedule_backup_delay_after_restore') %>
+    transaction_logs_delete_buffer_time: <%= p('backup.transaction_logs_delete_buffer_time') %>
     provider: <%= JSON.dump(p('backup.provider', nil)) %>
 
   #################################

--- a/jobs/service-fabrik-report/templates/config/settings.yml.erb
+++ b/jobs/service-fabrik-report/templates/config/settings.yml.erb
@@ -118,6 +118,7 @@ production:
     num_of_allowed_restores: <%= link("broker").p('backup.num_of_allowed_restores') %>
     restore_history_days: <%= link("broker").p('backup.restore_history_days') %>
     reschedule_backup_delay_after_restore: <%= link("broker").p('backup.reschedule_backup_delay_after_restore') %>
+    transaction_logs_delete_buffer_time: <%= link("broker").p('backup.transaction_logs_delete_buffer_time') %>
     provider: <%= JSON.dump(link("broker").p('backup.provider', nil)) %>
 
   #################################

--- a/jobs/service-fabrik-scheduler/templates/config/settings.yml.erb
+++ b/jobs/service-fabrik-scheduler/templates/config/settings.yml.erb
@@ -208,6 +208,7 @@ production:
     num_of_allowed_restores: <%= link("broker").p('backup.num_of_allowed_restores') %>
     restore_history_days: <%= link("broker").p('backup.restore_history_days') %>
     reschedule_backup_delay_after_restore: <%= link("broker").p('backup.reschedule_backup_delay_after_restore') %>
+    transaction_logs_delete_buffer_time: <%= link("broker").p('backup.transaction_logs_delete_buffer_time') %>
     provider: <%= JSON.dump(link("broker").p('backup.provider', nil)) %>
 
   #################################


### PR DESCRIPTION
This config indicates buffer time in minutes.

Transaction logs ideally should be deleted older than the last successful backup. This buffer time is added to the timestamp (in past) and logs are deleted which are older than that.

e.g. if transaction logs are to be deleted from 15th day, since the 15th day's backup was the last successful backup, then logs older than 15th day + buffer time will be deleted.