### PR TITLE
Rename managers to operators

### DIFF
--- a/jobs/service-fabrik-backup-manager/templates/bin/service-fabrik-backup-manager_ctl.erb
+++ b/jobs/service-fabrik-backup-manager/templates/bin/service-fabrik-backup-manager_ctl.erb
@@ -30,7 +30,7 @@ case $1 in
       --background \
       --no-close \
       --chdir ${PACKAGE_DIR} \
-      -- ${PACKAGE_DIR}/managers/StartBackupRestoreManagers.js \
+      -- ${PACKAGE_DIR}/operators/StartBackupRestoreOperators.js \
       1>> ${LOG_DIR}/${OUTPUT_LABEL}.stdout.log \
       2>> ${LOG_DIR}/${OUTPUT_LABEL}.stderr.log
     ;;

--- a/jobs/service-fabrik-bosh-manager/templates/bin/service-fabrik-bosh-manager_ctl.erb
+++ b/jobs/service-fabrik-bosh-manager/templates/bin/service-fabrik-bosh-manager_ctl.erb
@@ -30,7 +30,7 @@ case $1 in
       --background \
       --no-close \
       --chdir ${PACKAGE_DIR} \
-      -- ${PACKAGE_DIR}/managers/StartBoshManagers.js \
+      -- ${PACKAGE_DIR}/operators/StartBoshOperators.js \
       1>> ${LOG_DIR}/${OUTPUT_LABEL}.stdout.log \
       2>> ${LOG_DIR}/${OUTPUT_LABEL}.stderr.log
     ;;

--- a/jobs/service-fabrik-docker-manager/templates/bin/service-fabrik-docker-manager_ctl.erb
+++ b/jobs/service-fabrik-docker-manager/templates/bin/service-fabrik-docker-manager_ctl.erb
@@ -30,7 +30,7 @@ case $1 in
       --background \
       --no-close \
       --chdir ${PACKAGE_DIR} \
-      -- ${PACKAGE_DIR}/managers/StartDockerManagers.js \
+      -- ${PACKAGE_DIR}/operators/StartDockerOperators.js \
       1>> ${LOG_DIR}/${OUTPUT_LABEL}.stdout.log \
       2>> ${LOG_DIR}/${OUTPUT_LABEL}.stderr.log
     ;;

--- a/jobs/service-fabrik-virtualhost-manager/templates/bin/service-fabrik-virtualhost-manager_ctl.erb
+++ b/jobs/service-fabrik-virtualhost-manager/templates/bin/service-fabrik-virtualhost-manager_ctl.erb
@@ -30,7 +30,7 @@ case $1 in
       --background \
       --no-close \
       --chdir ${PACKAGE_DIR} \
-      -- ${PACKAGE_DIR}/managers/StartVirtualHostManagers.js \
+      -- ${PACKAGE_DIR}/operators/StartVirtualHostOperators.js \
       1>> ${LOG_DIR}/${OUTPUT_LABEL}.stdout.log \
       2>> ${LOG_DIR}/${OUTPUT_LABEL}.stderr.log
     ;;


### PR DESCRIPTION
In this PR only paths are changed.
We can evaluate the consequences of changing job name (logs).