### PR TITLE
Adding Kubeconfig to be used by go-client on sf-monitoring-agent

### DIFF
--- a/jobs/service-fabrik-apiserver/spec
+++ b/jobs/service-fabrik-apiserver/spec
@@ -14,6 +14,7 @@ templates:
   config/apiserver-key.pem.erb: config/apiserver-key.pem
   config/apiserver.pem.erb: config/apiserver.pem
   config/tokens.csv.erb: config/tokens.csv
+  config/kubeconfig.erb: config/kubeconfig
 
 provides:
 - name: service-fabrik-apiserver

--- a/jobs/service-fabrik-apiserver/templates/config/kubeconfig.erb
+++ b/jobs/service-fabrik-apiserver/templates/config/kubeconfig.erb
@@ -1,0 +1,23 @@
+<%
+  CA = link('service-fabrik-apiserver').p('tls.apiserver.ca')
+  CA_BASE64 = Base64.encode64(CA)
+  CA_TRIM = CA_BASE64.gsub("\n",'')
+%>
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: <%= CA_TRIM %>
+    server: https://127.0.0.1:9443
+  name: apiserver
+contexts:
+- context:
+    cluster: apiserver
+    user: apiserver/<%= p("admin-username") %>
+  name: apiserver
+current-context: apiserver
+kind: Config
+preferences: {}
+users:
+- name: apiserver/<%= p("admin-username") %>
+  user:
+    token: <%= p("admin-password") %>


### PR DESCRIPTION
The go-client introduced as part of sf-monitoring-agent, needs a default kubeconfig file to connect to API server and fetch metrics.