### PR TITLE
Adding apiserver certificates in service-fabrik-report job settings

### DIFF
--- a/jobs/service-fabrik-report/templates/config/settings.yml.erb
+++ b/jobs/service-fabrik-report/templates/config/settings.yml.erb
@@ -67,6 +67,10 @@ production:
   apiserver:
     ip: <%= link("service-fabrik-apiserver").p('ip') %>
     port: <%= link("service-fabrik-apiserver").p('port') %>
+    ca: <%= JSON.dump(link("service-fabrik-apiserver").p('tls.apiserver.ca')) %>
+    certificate: <%= JSON.dump(link("service-fabrik-apiserver").p('tls.apiserver.certificate')) %>
+    private_key: <%= JSON.dump(link("service-fabrik-apiserver").p('tls.apiserver.private_key')) %>
+    crds: <%= JSON.dump(link("service-fabrik-apiserver").p('crds')) %>
 
   ###################
   # QUOTA MANAGEMENT SETTINGS #


### PR DESCRIPTION
* With modifications in DbManager init flow to store/fetch credentials from ApiServer (see https://github.com/cloudfoundry-incubator/service-fabrik-broker/pull/468), service-fabrik-report job also needs to communicate to ApiServer, which wasn't the case earlier.  
* Therefore adding required certificates as part of service-fabrik-report job properties.