### PR TITLE
upgraded node to v8.14.0

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -54,10 +54,10 @@ libseccomp/libseccomp-2.3.3.tar.gz:
   size: 564546
   object_id: 4e749385-3bc6-45b5-7a08-906c3cf97573
   sha: 89b1f35447b1891a3051de979dc92ad9f7258b60
-node/node-v6.9.1-linux-x64.tar.xz:
-  size: 9351072
-  object_id: e79323b1-66d8-42a6-aba3-df4525ce82cd
-  sha: 84b0b6fde43a4d892186119ba6b9f1db3c2c6129
+node/node-v8.14.0-linux-x64.tar.xz:
+  size: 11322764
+  object_id: 35d41cae-73bd-48a4-7284-79e92455ded2
+  sha: b74889a4cbfda92760311826d13726939190dc60
 python/Python-2.7.6.tar.xz:
   size: 10431288
   object_id: 7f61b922-e0de-47ac-6eec-fb0b53a2e6ea

--- a/packages/node/spec
+++ b/packages/node/spec
@@ -1,4 +1,4 @@
 ---
 name: node
 files:
-  - node/node-v6.9.1-linux-x64.tar.xz
+  - node/node-v8.14.0-linux-x64.tar.xz


### PR DESCRIPTION
Current version of Node v6.9.0 LTS expires 2019 March and we need to upgrade it. Upgrading to latest version 10.13.0 is having an [issue](https://github.com/googleapis/nodejs-compute/issues/216) with gcp node dependency. Hence upgrading it to the intemediate LTS 8.14.0