### PR TITLE
Enable instance sharing on Cloud Foundry

### DIFF
--- a/jobs/service-fabrik-bosh-manager/templates/config/settings.yml.erb
+++ b/jobs/service-fabrik-bosh-manager/templates/config/settings.yml.erb
@@ -29,11 +29,13 @@ production:
   log_level: <%= link("broker").p('log_level') %>
   sys_log_level: <%= link("broker").p('sys_log_level') %>
   enable_bosh_rate_limit: <%= link("broker").p('enable_bosh_rate_limit') %>
+  enable_cross_organization_sharing: <%= link("broker").p('enable_cross_organization_sharing') %>
   enable_circuit_breaker: <%= link("broker").p('enable_circuit_breaker') %>
   enable_swarm_manager: <%= link("broker").p('enable_swarm_manager') %>
   feature:
     ServiceInstanceAutoUpdate: <%= link("broker").p('feature.ServiceInstanceAutoUpdate') %>
     EnableSecurityGroupsOps: <%= link("broker").p('feature.EnableSecurityGroupsOps') %>
+    AllowInstanceSharing: <%= link("broker").p('feature.AllowInstanceSharing') %>
   http_timeout: <%= link("broker").p('http_timeout') %>
   deployment_action_timeout: <%= link("broker").p('deployment_action_timeout') %>
   agent_operation_timeout: <%= link("broker").p('agent_operation_timeout') %>

--- a/jobs/service-fabrik-broker/spec
+++ b/jobs/service-fabrik-broker/spec
@@ -29,10 +29,12 @@ provides:
   - skip_ssl_validation
   - log_level
   - enable_bosh_rate_limit
+  - enable_cross_organization_sharing
   - enable_circuit_breaker
   - enable_swarm_manager
   - feature.ServiceInstanceAutoUpdate
   - feature.EnableSecurityGroupsOps
+  - feature.AllowInstanceSharing
   - broker_drain_message
   - http_timeout
   - deployment_action_timeout
@@ -148,6 +150,9 @@ properties:
   enable_bosh_rate_limit:
     description: "Switch used to turn on/off rate limiting against BOSH director"
     default: false
+  enable_cross_organization_sharing:
+    description: "Determines whether instances can be shared across CF organizations"
+    default: false
   enable_swarm_manager:
     description: "Determines whether the broker has dependency on swarm manager"
     default: true
@@ -156,6 +161,9 @@ properties:
     default: false
   feature.EnableSecurityGroupsOps:
     description: "Switch used to enable security groups related operations"
+    default: true
+  feature.AllowInstanceSharing:
+    description: "Switch used to turn on/off sharing instances on CF"
     default: true
   http_timeout:
     description: "Timeout duration for any request to broker"

--- a/jobs/service-fabrik-broker/templates/config/settings.yml.erb
+++ b/jobs/service-fabrik-broker/templates/config/settings.yml.erb
@@ -30,11 +30,13 @@ production:
   log_level: <%= p('log_level') %>
   sys_log_level: <%= p('sys_log_level') %>
   enable_bosh_rate_limit: <%= p('enable_bosh_rate_limit') %>
+  enable_cross_organization_sharing: <%= p('enable_cross_organization_sharing') %>
   enable_circuit_breaker: <%= p('enable_circuit_breaker') %>
   enable_swarm_manager: <%= p('enable_swarm_manager') %>
   feature:
     ServiceInstanceAutoUpdate: <%= p('feature.ServiceInstanceAutoUpdate') %>
     EnableSecurityGroupsOps: <%= p('feature.EnableSecurityGroupsOps') %>
+    AllowInstanceSharing: <%= p('feature.AllowInstanceSharing') %>
   http_timeout: <%= p('http_timeout') %>
   deployment_action_timeout: <%= p('deployment_action_timeout') %>
   agent_operation_timeout: <%= p('agent_operation_timeout') %>


### PR DESCRIPTION
- Include feature flag for allowing sharing of instances
- Include control flag for allowing/disallowing cross-CF organization sharing