### PR TITLE
Adding service fabrik Interoperator job

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,5 @@
 [submodule "src/service-fabrik-broker"]
-	path = src/service-fabrik-broker
+	path = src/github.com/cloudfoundry-incubator/service-fabrik-broker
 	url = https://github.com/sap/service-fabrik-broker.git
 [submodule "src/github.com/docker/swarm"]
 	path = src/github.com/docker/swarm

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -38,6 +38,10 @@ golang/go1.8.3.linux-amd64.tar.gz:
   size: 90029041
   object_id: 531dbe5c-f65b-4c3a-a524-c630a7762567
   sha: 838c415896ef5ecd395dfabde5e7e6f8ac943c8e
+golang/go1.11.4.linux-amd64.tar.gz:
+  size: 126643341
+  object_id: b399f06d-3af0-4e3f-7103-41c0446f6ef6
+  sha: 52bd8eb353a39138a2ddf053857a0fd13f1f176c
 jq/jq:
   size: 497799
   object_id: 61d27ef5-32cc-439d-6842-97be75dae6fb
@@ -54,6 +58,10 @@ kubernetes-1.12.4/kube-apiserver:
   size: 192825094
   object_id: 99e8f3b2-192f-4ac3-487f-18245b786565
   sha: 265d1fd6c34785b5610b5a3ce95d6af755c9c97f
+kubernetes-1.12.4/kubectl:
+  size: 57374117
+  object_id: 49cad09c-bb7b-4e37-5825-3e186b2c26f3
+  sha: c289e26cabe85ad3edd91103bbf03352ee2e50a0
 libseccomp/libseccomp-2.3.3.tar.gz:
   size: 564546
   object_id: 4e749385-3bc6-45b5-7a08-906c3cf97573

--- a/jobs/service-fabrik-apiserver/spec
+++ b/jobs/service-fabrik-apiserver/spec
@@ -26,6 +26,8 @@ provides:
   - tls.apiserver.certificate
   - tls.apiserver.private_key
   - crds
+  - admin-username
+  - admin-password
 
 properties:
   logging-level:

--- a/jobs/service-fabrik-interoperator/monit
+++ b/jobs/service-fabrik-interoperator/monit
@@ -1,0 +1,6 @@
+check process service-fabrik-interoperator
+  with pidfile /var/vcap/sys/run/bpm/service-fabrik-interoperator/service-fabrik-interoperator.pid
+  depends on service-fabrik-apiserver
+  start program "/var/vcap/jobs/bpm/bin/bpm start service-fabrik-interoperator"
+  stop program "/var/vcap/jobs/bpm/bin/bpm stop service-fabrik-interoperator"
+  group vcap

--- a/jobs/service-fabrik-interoperator/spec
+++ b/jobs/service-fabrik-interoperator/spec
@@ -1,0 +1,15 @@
+---
+name: service-fabrik-interoperator
+
+packages:
+  - interoperator
+  - kubectl
+
+templates:
+  bin/pre_start.erb: bin/pre_start
+  config/bpm.yml.erb: config/bpm.yml
+  config/kubeconfig.yaml.erb: config/kubeconfig.yaml
+
+consumes:
+- name: service-fabrik-apiserver
+  type: service-fabrik-apiserver

--- a/jobs/service-fabrik-interoperator/templates/bin/pre_start.erb
+++ b/jobs/service-fabrik-interoperator/templates/bin/pre_start.erb
@@ -1,0 +1,9 @@
+#!/bin/bash -e
+
+[ -z "$DEBUG" ] || set -x
+
+echo "Applying CRDs before creating the interoperator process"
+
+export KUBECONFIG=/var/vcap/jobs/service-fabrik-interoperator/config/kubeconfig.yaml
+
+/var/vcap/packages/kubectl/bin/kubectl apply -f /var/vcap/packages/interoperator/src/github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/config/crds

--- a/jobs/service-fabrik-interoperator/templates/config/bpm.yml.erb
+++ b/jobs/service-fabrik-interoperator/templates/config/bpm.yml.erb
@@ -1,0 +1,14 @@
+---
+<%
+JOB_PATH = "/var/vcap/jobs/service-fabrik-interoperator"
+CONFIG_PATH = "/var/vcap/jobs/service-fabrik-interoperator/config"
+%>
+processes:
+- name: service-fabrik-interoperator
+  executable: /var/vcap/packages/interoperator/bin/manager
+  env:
+    KUBECONFIG: <%= CONFIG_PATH %>/kubeconfig.yaml
+  limits:
+    open_files: 100000
+  hooks:
+    pre_start: <%= JOB_PATH %>/bin/pre_start

--- a/jobs/service-fabrik-interoperator/templates/config/kubeconfig.yaml.erb
+++ b/jobs/service-fabrik-interoperator/templates/config/kubeconfig.yaml.erb
@@ -7,7 +7,7 @@ apiVersion: v1
 clusters:
 - cluster:
     certificate-authority-data: "<%= CA_BASE64 %>"
-    server: "https://<%= link('service-fabrik-apiserver').p('ip') %>:<%= link('service-fabrik-apiserver').p('port') %>"
+    server: "https://127.0.0.1:<%= link('service-fabrik-apiserver').p('port') %>"
   name: apiserver
 contexts:
 - context:

--- a/jobs/service-fabrik-interoperator/templates/config/kubeconfig.yaml.erb
+++ b/jobs/service-fabrik-interoperator/templates/config/kubeconfig.yaml.erb
@@ -1,0 +1,23 @@
+<%
+  CA = link('service-fabrik-apiserver').p('tls.apiserver.ca')
+  CA_BASE64 = Base64.strict_encode64(CA)
+%>
+---
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: "<%= CA_BASE64 %>"
+    server: "https://<%= link('service-fabrik-apiserver').p('ip') %>:<%= link('service-fabrik-apiserver').p('port') %>"
+  name: apiserver
+contexts:
+- context:
+    cluster: apiserver
+    user: apiserver/<%= link('service-fabrik-apiserver').p('admin-username') %>
+  name: apiserver
+current-context: apiserver
+kind: Config
+preferences: {}
+users:
+- name: apiserver/<%= link('service-fabrik-apiserver').p('admin-username') %>
+  user:
+    token: <%= link('service-fabrik-apiserver').p('admin-password') %>

--- a/jobs/webhooks/templates/config/webhooks.json.erb
+++ b/jobs/webhooks/templates/config/webhooks.json.erb
@@ -1,6 +1,6 @@
 <%
   CA = link('service-fabrik-apiserver').p('tls.apiserver.ca')
-  CA_BASE64 = Base64.encode64(CA)
+  CA_BASE64 = Base64.strict_encode64(CA)
 %>
 {
   "metadata": {

--- a/packages/golang/spec
+++ b/packages/golang/spec
@@ -2,4 +2,4 @@
 name: golang
 dependencies: []
 files:
-  - golang/go1.8.3.linux-amd64.tar.gz
+  - golang/go1.11.4.linux-amd64.tar.gz

--- a/packages/interoperator/packaging
+++ b/packages/interoperator/packaging
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e # exit immediately if a simple command exits with a non-zero status
+set -u # report the usage of uninitialized variables
+
+# Set Golang dependency
+export GOROOT=$(readlink -nf /var/vcap/packages/golang)
+export PATH=${GOROOT}/bin:${PATH}
+
+# Build Interoperator package
+echo "Building Interoperator..."
+PACKAGE_NAME=github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator
+mkdir -p ${BOSH_INSTALL_TARGET}/src/${PACKAGE_NAME}
+cp -a ${BOSH_COMPILE_TARGET}/${PACKAGE_NAME}/* ${BOSH_INSTALL_TARGET}/src/${PACKAGE_NAME}
+export GOPATH=${BOSH_INSTALL_TARGET}
+cd ${BOSH_INSTALL_TARGET}
+
+go build -o bin/manager ${PACKAGE_NAME}/cmd/manager

--- a/packages/interoperator/pre_packaging
+++ b/packages/interoperator/pre_packaging
@@ -19,7 +19,7 @@ set -u
   # install dep 
   curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
   # Install production dependencies
-  dep ensure -v
+  ${GOPATH}/bin/dep ensure -v
 
   cp -R ${GOPATH}/src/github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/vendor ${BUILD_DIR}/github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator
 

--- a/packages/interoperator/pre_packaging
+++ b/packages/interoperator/pre_packaging
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -e
+set -u
+
+(
+  echo ${BUILD_DIR}
+  cd ${BUILD_DIR}
+  cd ..
+  export GOPATH=$(pwd)
+  mkdir -p ${GOPATH}/bin
+  mkdir -p ${GOPATH}/src
+
+  rm -rf ${GOPATH}/src/github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator
+
+  cp -R ${BUILD_DIR}/github.com ${GOPATH}/src
+  cd ${GOPATH}/src/github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator
+
+  # install dep 
+  curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+  # Install production dependencies
+  dep ensure -v
+
+  cp -R ${GOPATH}/src/github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/vendor ${BUILD_DIR}/github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator
+
+  cd ${BUILD_DIR}/github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator
+  # Precompile static files if needed
+
+  # Remove unneeded files
+  rm -rf docs
+  rm -rf logs/*
+)

--- a/packages/interoperator/spec
+++ b/packages/interoperator/spec
@@ -1,0 +1,8 @@
+---
+name: interoperator
+
+dependencies:
+  - golang
+
+files:
+  - github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/**/*

--- a/packages/kubectl/packaging
+++ b/packages/kubectl/packaging
@@ -1,0 +1,7 @@
+set -e
+
+KUBERENETES_RELEASE_VERSION="1.12.4"
+
+mkdir -p "${BOSH_INSTALL_TARGET:?}/bin"
+cp -a kubernetes-${KUBERENETES_RELEASE_VERSION}/kubectl "${BOSH_INSTALL_TARGET:?}/bin"
+chmod +x "${BOSH_INSTALL_TARGET:?}/bin/kubectl"

--- a/packages/kubectl/spec
+++ b/packages/kubectl/spec
@@ -1,0 +1,5 @@
+---
+name: kubectl
+
+files:
+- kubernetes-1.12.4/kubectl

--- a/packages/service-fabrik-broker/packaging
+++ b/packages/service-fabrik-broker/packaging
@@ -6,7 +6,7 @@ PATH=/var/vcap/packages/node/bin:$PATH
 
 # Copy package
 echo "Copying service fabrik broker files..."
-cp -a ${BOSH_COMPILE_TARGET}/service-fabrik-broker/* ${BOSH_INSTALL_TARGET}/
+cp -a ${BOSH_COMPILE_TARGET}/github.com/cloudfoundry-incubator/service-fabrik-broker/* ${BOSH_INSTALL_TARGET}/
 
 #Added the below line to avoid node-gyp connect to internet and download headers during "npm rebuild"
 #which internally calls "node-gyp rebuild" of unix-dgram package based on https://github.com/nodejs/node-gyp/issues/1020

--- a/packages/service-fabrik-broker/pre_packaging
+++ b/packages/service-fabrik-broker/pre_packaging
@@ -4,7 +4,7 @@ set -e
 set -u
 
 (
-  cd ${BUILD_DIR}/service-fabrik-broker
+  cd ${BUILD_DIR}/github.com/cloudfoundry-incubator/service-fabrik-broker
 
   # Install production dependencies
   npm install --production
@@ -20,4 +20,5 @@ set -u
   rm -rf logs/*
   rm -rf store
   rm -rf test
+  rm -rf interoperator
 )

--- a/packages/service-fabrik-broker/spec
+++ b/packages/service-fabrik-broker/spec
@@ -3,4 +3,4 @@ name: service-fabrik-broker
 dependencies:
   - node
 files:
-  - service-fabrik-broker/**/*
+  - github.com/cloudfoundry-incubator/service-fabrik-broker/**/*

--- a/packages/service-fabrik-deployment-hooks/packaging
+++ b/packages/service-fabrik-deployment-hooks/packaging
@@ -6,7 +6,7 @@ PATH=/var/vcap/packages/node/bin:$PATH
 
 # Copy package
 echo "Copying service fabrik deployment hooks files..."
-cp -a ${BOSH_COMPILE_TARGET}/service-fabrik-broker/{package.json,deployment_hooks,common,node_modules} ${BOSH_INSTALL_TARGET}/
+cp -a ${BOSH_COMPILE_TARGET}/github.com/cloudfoundry-incubator/service-fabrik-broker/{package.json,deployment_hooks,common,node_modules} ${BOSH_INSTALL_TARGET}/
 
 #Added the below line to avoid node-gyp connect to internet and download headers during "npm rebuild"
 #which internally calls "node-gyp rebuild" of unix-dgram package based on https://github.com/nodejs/node-gyp/issues/1020

--- a/packages/service-fabrik-deployment-hooks/pre_packaging
+++ b/packages/service-fabrik-deployment-hooks/pre_packaging
@@ -4,7 +4,7 @@ set -e
 set -u
 
 (
-  cd ${BUILD_DIR}/service-fabrik-broker
+  cd ${BUILD_DIR}/github.com/cloudfoundry-incubator/service-fabrik-broker
 
   # Install production dependencies
   npm install --production

--- a/packages/service-fabrik-deployment-hooks/spec
+++ b/packages/service-fabrik-deployment-hooks/spec
@@ -4,6 +4,6 @@ dependencies:
   - node
   - libseccomp
 files:
-  - service-fabrik-broker/deployment_hooks/**/*
-  - service-fabrik-broker/common/**/*
-  - service-fabrik-broker/package.json
+  - github.com/cloudfoundry-incubator/service-fabrik-broker/deployment_hooks/**/*
+  - github.com/cloudfoundry-incubator/service-fabrik-broker/common/**/*
+  - github.com/cloudfoundry-incubator/service-fabrik-broker/package.json


### PR DESCRIPTION
* Changed the submodule path of service fabrik broker to facilitate go build of interoperator
* Corresponding path changes done in service fabrik broker and deployment-hooks packages
* Added two new blobs, one for new go1.11.4 version and another for kubectl binary
* Added kubectl package and modified golang package to use 1.11.4 version
* Added interoperator package and job
* modified webhook job's config file to use strict base64 encoding