### PR TITLE
deployment hooks had missed copying package.json

### DIFF
--- a/packages/service-fabrik-deployment-hooks/packaging
+++ b/packages/service-fabrik-deployment-hooks/packaging
@@ -6,7 +6,7 @@ PATH=/var/vcap/packages/node/bin:$PATH
 
 # Copy package
 echo "Copying service fabrik deployment hooks files..."
-cp -a ${BOSH_COMPILE_TARGET}/service-fabrik-broker/{deployment_hooks,common,node_modules} ${BOSH_INSTALL_TARGET}/
+cp -a ${BOSH_COMPILE_TARGET}/service-fabrik-broker/{package.json,deployment_hooks,common,node_modules} ${BOSH_INSTALL_TARGET}/
 
 #Added the below line to avoid node-gyp connect to internet and download headers during "npm rebuild"
 #which internally calls "node-gyp rebuild" of unix-dgram package based on https://github.com/nodejs/node-gyp/issues/1020


### PR DESCRIPTION
package.json file is missed out from copying while creating deployment hooks package from broker. This omit is making the deployments hook compilation to fail on xenial stemcell. This fixes the compilation issue on xenial.