### PR TITLE
Move ModLoads in Rsyslog to one single Configuration-File

### DIFF
--- a/jobs/docker/templates/bin/docker_ctl.erb
+++ b/jobs/docker/templates/bin/docker_ctl.erb
@@ -36,6 +36,13 @@ case $1 in
     # Enable syslog forwarding to logstash
     if [ ! -L /etc/rsyslog.d/45-docker_log_forwarding.conf ]; then
         ln -s /var/vcap/jobs/docker/config/syslog_forwarding.conf /etc/rsyslog.d/45-docker_log_forwarding.conf
+        if [ ! -e  /etc/rsyslog.d/10-fabrik_modules.conf ]; then
+            mkdir -p /var/vcap/data/docker
+            touch /var/vcap/data/docker/syslog_modules.conf
+            ln -sf /var/vcap/data/docker/syslog_modules.conf /etc/rsyslog.d/10-fabrik_modules.conf
+        fi
+        if ! grep -Fxq "\$ModLoad imtcp" /etc/rsyslog.d/10-fabrik_modules.conf ; then echo "\$ModLoad imtcp" >> /etc/rsyslog.d/10-fabrik_modules.conf ; fi
+        if ! grep -Fxq "\$ModLoad imfile" /etc/rsyslog.d/10-fabrik_modules.conf ; then echo "\$ModLoad imfile" >> /etc/rsyslog.d/10-fabrik_modules.conf ; fi
     fi
     /usr/sbin/service rsyslog restart
 

--- a/jobs/docker/templates/config/syslog_forwarding.conf.erb
+++ b/jobs/docker/templates/config/syslog_forwarding.conf.erb
@@ -5,7 +5,6 @@ docker_name = p('docker.name')
 docker_logs_dir = p('docker.logs_dir')
 %>
 
-$ModLoad imfile
 
 #variables required for non-syslog log file forwarding – SystemErr
 $WorkDirectory <%= docker_logs_dir %>
@@ -18,7 +17,6 @@ $InputRunFileMonitor
 
 
 
-$ModLoad imtcp
 $InputTCPServerRun 514
 
 template(

--- a/jobs/service-fabrik-backup-manager/templates/bin/service-fabrik-backup-manager_ctl.erb
+++ b/jobs/service-fabrik-backup-manager/templates/bin/service-fabrik-backup-manager_ctl.erb
@@ -19,6 +19,12 @@ case $1 in
     # Enable syslog forwarding to logstash
     if [ ! -L /etc/rsyslog.d/52-fabrik_backup-manager_forwarding.conf ]; then
         ln -s ${CONF_DIR}/syslog_forwarding.conf /etc/rsyslog.d/52-fabrik_backup-manager_forwarding.conf
+        if [ ! -e  /etc/rsyslog.d/10-fabrik_modules.conf ]; then
+            mkdir -p /var/vcap/data/service-fabrik-backup-manager
+            touch /var/vcap/data/service-fabrik-backup-manager/syslog_modules.conf
+            ln -sf /var/vcap/data/service-fabrik-backup-manager/syslog_modules.conf /etc/rsyslog.d/10-fabrik_modules.conf
+        fi
+        if ! grep -Fxq "\$ModLoad imtcp" /etc/rsyslog.d/10-fabrik_modules.conf ; then echo "\$ModLoad imtcp" >> /etc/rsyslog.d/10-fabrik_modules.conf ; fi
     fi
     /usr/sbin/service rsyslog restart
 

--- a/jobs/service-fabrik-backup-manager/templates/config/syslog_forwarding.conf.erb
+++ b/jobs/service-fabrik-backup-manager/templates/config/syslog_forwarding.conf.erb
@@ -3,7 +3,6 @@ network = spec.networks.methods(false).first
 ip = spec.networks.send(network).ip
 %>
 
-$ModLoad imtcp
 $InputTCPServerRun 514
 
 template(

--- a/jobs/service-fabrik-bosh-manager/templates/bin/service-fabrik-bosh-manager_ctl.erb
+++ b/jobs/service-fabrik-bosh-manager/templates/bin/service-fabrik-bosh-manager_ctl.erb
@@ -19,6 +19,12 @@ case $1 in
     # Enable syslog forwarding to logstash
     if [ ! -L /etc/rsyslog.d/52-fabrik_bosh-manager_forwarding.conf ]; then
         ln -s ${CONF_DIR}/syslog_forwarding.conf /etc/rsyslog.d/52-fabrik_bosh-manager_forwarding.conf
+        if [ ! -e  /etc/rsyslog.d/10-fabrik_modules.conf ]; then
+            mkdir -p /var/vcap/data/service-fabrik-bosh-manager
+            touch /var/vcap/data/service-fabrik-bosh-manager/syslog_modules.conf
+            ln -sf /var/vcap/data/service-fabrik-bosh-manager/syslog_modules.conf /etc/rsyslog.d/10-fabrik_modules.conf
+        fi
+        if ! grep -Fxq "\$ModLoad imtcp" /etc/rsyslog.d/10-fabrik_modules.conf ; then echo "\$ModLoad imtcp" >> /etc/rsyslog.d/10-fabrik_modules.conf ; fi
     fi
     /usr/sbin/service rsyslog restart
 

--- a/jobs/service-fabrik-bosh-manager/templates/config/syslog_forwarding.conf.erb
+++ b/jobs/service-fabrik-bosh-manager/templates/config/syslog_forwarding.conf.erb
@@ -3,7 +3,6 @@ network = spec.networks.methods(false).first
 ip = spec.networks.send(network).ip
 %>
 
-$ModLoad imtcp
 $InputTCPServerRun 514
 
 template(

--- a/jobs/service-fabrik-broker/templates/bin/service-fabrik-broker_ctl.erb
+++ b/jobs/service-fabrik-broker/templates/bin/service-fabrik-broker_ctl.erb
@@ -19,6 +19,12 @@ case $1 in
     # Enable syslog forwarding to logstash
     if [ ! -L /etc/rsyslog.d/49-fabrik_forwarding.conf ]; then
         ln -s /var/vcap/jobs/service-fabrik-broker/config/syslog_forwarding.conf /etc/rsyslog.d/49-fabrik_forwarding.conf
+        if [ ! -e  /etc/rsyslog.d/10-fabrik_modules.conf ]; then
+            mkdir -p /var/vcap/data/service-fabrik-broker
+            touch /var/vcap/data/service-fabrik-broker/syslog_modules.conf
+            ln -sf /var/vcap/data/service-fabrik-broker/syslog_modules.conf /etc/rsyslog.d/10-fabrik_modules.conf
+        fi
+        if ! grep -Fxq "\$ModLoad imtcp" /etc/rsyslog.d/10-fabrik_modules.conf ; then echo "\$ModLoad imtcp" >> /etc/rsyslog.d/10-fabrik_modules.conf ; fi
     fi
     /usr/sbin/service rsyslog restart
     

--- a/jobs/service-fabrik-broker/templates/config/syslog_forwarding.conf.erb
+++ b/jobs/service-fabrik-broker/templates/config/syslog_forwarding.conf.erb
@@ -3,7 +3,6 @@ network = spec.networks.methods(false).first
 ip = spec.networks.send(network).ip
 %>
 
-$ModLoad imtcp
 $InputTCPServerRun 514
 
 template(

--- a/jobs/service-fabrik-docker-manager/templates/bin/service-fabrik-docker-manager_ctl.erb
+++ b/jobs/service-fabrik-docker-manager/templates/bin/service-fabrik-docker-manager_ctl.erb
@@ -19,6 +19,12 @@ case $1 in
     # Enable syslog forwarding to logstash
     if [ ! -L /etc/rsyslog.d/52-fabrik_docker-manager_forwarding.conf ]; then
         ln -s ${CONF_DIR}/syslog_forwarding.conf /etc/rsyslog.d/52-fabrik_docker-manager_forwarding.conf
+        if [ ! -e  /etc/rsyslog.d/10-fabrik_modules.conf ]; then
+            mkdir -p /var/vcap/data/service-fabrik-docker-manager
+            touch /var/vcap/data/service-fabrik-docker-manager/syslog_modules.conf
+            ln -sf /var/vcap/data/service-fabrik-docker-manager/syslog_modules.conf /etc/rsyslog.d/10-fabrik_modules.conf
+        fi
+        if ! grep -Fxq "\$ModLoad imtcp" /etc/rsyslog.d/10-fabrik_modules.conf ; then echo "\$ModLoad imtcp" >> /etc/rsyslog.d/10-fabrik_modules.conf ; fi
     fi
     /usr/sbin/service rsyslog restart
 

--- a/jobs/service-fabrik-docker-manager/templates/config/syslog_forwarding.conf.erb
+++ b/jobs/service-fabrik-docker-manager/templates/config/syslog_forwarding.conf.erb
@@ -3,7 +3,6 @@ network = spec.networks.methods(false).first
 ip = spec.networks.send(network).ip
 %>
 
-$ModLoad imtcp
 $InputTCPServerRun 514
 
 template(

--- a/jobs/service-fabrik-postgresqlmt-operator/templates/bin/pre_start.erb
+++ b/jobs/service-fabrik-postgresqlmt-operator/templates/bin/pre_start.erb
@@ -7,4 +7,10 @@ source /var/vcap/packages/bosh-helpers/ctl_setup.sh 'service-fabrik-postgresqlmt
 # Enable syslog forwarding to logstash
 if [ ! -L /etc/rsyslog.d/52-fabrik_postgresqlmt-operator_forwarding.conf ]; then
   ln -s ${CONF_DIR}/syslog_forwarding.conf /etc/rsyslog.d/52-fabrik_postgresqlmt-operator_forwarding.conf
+  if [ ! -e  /etc/rsyslog.d/10-fabrik_modules.conf ]; then
+    mkdir -p /var/vcap/data/service-fabrik-postgresqlmt-operator
+    touch /var/vcap/data/service-fabrik-postgresqlmt-operator/syslog_modules.conf
+    ln -sf /var/vcap/data/service-fabrik-postgresqlmt-operator/syslog_modules.conf /etc/rsyslog.d/10-fabrik_modules.conf
+  fi
+  if ! grep -Fxq "\$ModLoad imtcp" /etc/rsyslog.d/10-fabrik_modules.conf ; then echo "\$ModLoad imtcp" >> /etc/rsyslog.d/10-fabrik_modules.conf ; fi
 fi

--- a/jobs/service-fabrik-postgresqlmt-operator/templates/config/syslog_forwarding.conf.erb
+++ b/jobs/service-fabrik-postgresqlmt-operator/templates/config/syslog_forwarding.conf.erb
@@ -4,7 +4,6 @@ ip = spec.networks.send(network).ip
 processname = "service-fabrik-postgresqlmt-operator"
 %>
 
-$ModLoad imtcp
 $InputTCPServerRun 514
 
 template(

--- a/jobs/service-fabrik-report/templates/bin/service-fabrik-report_ctl.erb
+++ b/jobs/service-fabrik-report/templates/bin/service-fabrik-report_ctl.erb
@@ -19,6 +19,12 @@ case $1 in
     # Enable syslog forwarding to logstash
     if [ ! -L /etc/rsyslog.d/51-fabrik_report_forwarding.conf ]; then
         ln -s ${CONF_DIR}/syslog_forwarding.conf /etc/rsyslog.d/51-fabrik_report_forwarding.conf
+        if [ ! -e  /etc/rsyslog.d/10-fabrik_modules.conf ]; then
+            mkdir -p /var/vcap/data/service-fabrik-report
+            touch /var/vcap/data/service-fabrik-report/syslog_modules.conf
+            ln -sf /var/vcap/data/service-fabrik-report/syslog_modules.conf /etc/rsyslog.d/10-fabrik_modules.conf
+        fi
+        if ! grep -Fxq "\$ModLoad imtcp" /etc/rsyslog.d/10-fabrik_modules.conf ; then echo "\$ModLoad imtcp" >> /etc/rsyslog.d/10-fabrik_modules.conf ; fi
     fi
     /usr/sbin/service rsyslog restart
 

--- a/jobs/service-fabrik-report/templates/config/syslog_forwarding.conf.erb
+++ b/jobs/service-fabrik-report/templates/config/syslog_forwarding.conf.erb
@@ -3,7 +3,6 @@ network = spec.networks.methods(false).first
 ip = spec.networks.send(network).ip
 %>
 
-$ModLoad imtcp
 $InputTCPServerRun 514
 
 template(

--- a/jobs/service-fabrik-scheduler/templates/bin/service-fabrik-scheduler_ctl.erb
+++ b/jobs/service-fabrik-scheduler/templates/bin/service-fabrik-scheduler_ctl.erb
@@ -19,6 +19,12 @@ case $1 in
     # Enable syslog forwarding to logstash
     if [ ! -L /etc/rsyslog.d/50-fabrik_job_scheduler_forwarding.conf ]; then
         ln -s ${CONF_DIR}/syslog_forwarding.conf /etc/rsyslog.d/50-fabrik_job_scheduler_forwarding.conf
+        if [ ! -e  /etc/rsyslog.d/10-fabrik_modules.conf ]; then
+            mkdir -p /var/vcap/data/service-fabrik-scheduler
+            touch /var/vcap/data/service-fabrik-scheduler/syslog_modules.conf
+            ln -sf /var/vcap/data/service-fabrik-scheduler/syslog_modules.conf /etc/rsyslog.d/10-fabrik_modules.conf
+        fi
+        if ! grep -Fxq "\$ModLoad imtcp" /etc/rsyslog.d/10-fabrik_modules.conf ; then echo "\$ModLoad imtcp" >> /etc/rsyslog.d/10-fabrik_modules.conf ; fi
     fi
     /usr/sbin/service rsyslog restart
 

--- a/jobs/service-fabrik-scheduler/templates/config/syslog_forwarding.conf.erb
+++ b/jobs/service-fabrik-scheduler/templates/config/syslog_forwarding.conf.erb
@@ -3,7 +3,6 @@ network = spec.networks.methods(false).first
 ip = spec.networks.send(network).ip
 %>
 
-$ModLoad imtcp
 $InputTCPServerRun 514
 
 template(

--- a/jobs/service-fabrik-serviceflow-manager/templates/bin/pre_start.erb
+++ b/jobs/service-fabrik-serviceflow-manager/templates/bin/pre_start.erb
@@ -7,4 +7,10 @@ source /var/vcap/packages/bosh-helpers/ctl_setup.sh 'service-fabrik-serviceflow-
 # Enable syslog forwarding to logstash
 if [ ! -L /etc/rsyslog.d/53-fabrik_serviceflow-manager_forwarding.conf ]; then
   ln -s ${CONF_DIR}/syslog_forwarding.conf /etc/rsyslog.d/53-fabrik_serviceflow-manager_forwarding.conf
+  if [ ! -e  /etc/rsyslog.d/10-fabrik_modules.conf ]; then
+    mkdir -p /var/vcap/data/service-fabrik-serviceflow-manager
+    touch /var/vcap/data/service-fabrik-serviceflow-manager/syslog_modules.conf
+    ln -sf /var/vcap/data/service-fabrik-serviceflow-manager/syslog_modules.conf /etc/rsyslog.d/10-fabrik_modules.conf
+  fi
+  if ! grep -Fxq "\$ModLoad imtcp" /etc/rsyslog.d/10-fabrik_modules.conf ; then echo "\$ModLoad imtcp" >> /etc/rsyslog.d/10-fabrik_modules.conf ; fi
 fi

--- a/jobs/service-fabrik-serviceflow-manager/templates/config/syslog_forwarding.conf.erb
+++ b/jobs/service-fabrik-serviceflow-manager/templates/config/syslog_forwarding.conf.erb
@@ -3,7 +3,6 @@ network = spec.networks.methods(false).first
 ip = spec.networks.send(network).ip
 %>
 
-$ModLoad imtcp
 $InputTCPServerRun 514
 
 template(

--- a/jobs/service-fabrik-virtualhost-manager/templates/bin/service-fabrik-virtualhost-manager_ctl.erb
+++ b/jobs/service-fabrik-virtualhost-manager/templates/bin/service-fabrik-virtualhost-manager_ctl.erb
@@ -19,6 +19,12 @@ case $1 in
     # Enable syslog forwarding to logstash
     if [ ! -L /etc/rsyslog.d/52-fabrik_virtualhost-manager_forwarding.conf ]; then
         ln -s ${CONF_DIR}/syslog_forwarding.conf /etc/rsyslog.d/52-fabrik_virtualhost-manager_forwarding.conf
+        if [ ! -e  /etc/rsyslog.d/10-fabrik_modules.conf ]; then
+            mkdir -p /var/vcap/data/service-fabrik-virtualhost-manager
+            touch /var/vcap/data/service-fabrik-virtualhost-manager/syslog_modules.conf
+            ln -sf /var/vcap/data/service-fabrik-virtualhost-manager/syslog_modules.conf /etc/rsyslog.d/10-fabrik_modules.conf
+        fi
+        if ! grep -Fxq "\$ModLoad imtcp" /etc/rsyslog.d/10-fabrik_modules.conf ; then echo "\$ModLoad imtcp" >> /etc/rsyslog.d/10-fabrik_modules.conf ; fi
     fi
     /usr/sbin/service rsyslog restart
 

--- a/jobs/service-fabrik-virtualhost-manager/templates/config/syslog_forwarding.conf.erb
+++ b/jobs/service-fabrik-virtualhost-manager/templates/config/syslog_forwarding.conf.erb
@@ -3,7 +3,6 @@ network = spec.networks.methods(false).first
 ip = spec.networks.send(network).ip
 %>
 
-$ModLoad imtcp
 $InputTCPServerRun 514
 
 template(

--- a/jobs/swarm_manager/templates/bin/swarm_manager_ctl
+++ b/jobs/swarm_manager/templates/bin/swarm_manager_ctl
@@ -15,6 +15,13 @@ case $1 in
     # Enable syslog forwarding to logstash
     if [ ! -L /etc/rsyslog.d/45-swarm_manager_forwarding.conf ]; then
         ln -s /var/vcap/jobs/swarm_manager/config/syslog_forwarding.conf /etc/rsyslog.d/45-swarm_manager_forwarding.conf
+        if [ ! -e  /etc/rsyslog.d/10-fabrik_modules.conf ]; then
+            mkdir -p /var/vcap/data/swarm_manager
+            touch /var/vcap/data/swarm_manager/syslog_modules.conf
+            ln -sf /var/vcap/data/swarm_manager/syslog_modules.conf /etc/rsyslog.d/10-fabrik_modules.conf
+        fi
+        if ! grep -Fxq "\$ModLoad imtcp" /etc/rsyslog.d/10-fabrik_modules.conf ; then echo "\$ModLoad imtcp" >> /etc/rsyslog.d/10-fabrik_modules.conf ; fi
+        if ! grep -Fxq "\$ModLoad imfile" /etc/rsyslog.d/10-fabrik_modules.conf ; then echo "\$ModLoad imfile" >> /etc/rsyslog.d/10-fabrik_modules.conf ; fi
     fi
     set +e
     /usr/sbin/service rsyslog restart

--- a/jobs/swarm_manager/templates/config/syslog_forwarding.conf.erb
+++ b/jobs/swarm_manager/templates/config/syslog_forwarding.conf.erb
@@ -5,7 +5,6 @@ swarm_name= p('swarm.name')
 swarm_logs_dir=p('swarm_manager.logs_dir')
 %>
 
-$ModLoad imfile
 
 #variables required for non-syslog log file forwarding – SystemErr
 $WorkDirectory <%= swarm_logs_dir %>
@@ -16,9 +15,6 @@ $InputFileSeverity error
 $InputFileFacility local7
 $InputRunFileMonitor
 
-
-
-$ModLoad imtcp
 $InputTCPServerRun 514
 
 template(


### PR DESCRIPTION
## Desciption 

There is an Issue in the RSyslog-Configuration, where several Jobs deploy a Configuration which imports the module “imtcp”. Since Rsyslog concatenates all configation-Files to one single Configuration, “imtcp” is imported multiple times.
This causes the Rsyslog to produce warnings which are treated as errors by its debug-tool rsyslogd.

```
rsyslogd -N4
rsyslogd: version 8.39.0, config validation run (level 4), master config /etc/rsyslog.conf
rsyslogd: module 'imtcp' already in this config, cannot be added  [v8.39.0 try http://www.rsyslog.com/e/2221 ]
echo $?
1
```

Any deployment which uses Rsyslogd to check its own Configuration will then fail.

This PR will move the “ModLoad”-Commands to one single Configuration file.

### Changes

- Move `$ModLoad imtcp` to  `10-fabrik_modules.conf`
- Move `$ModLoad imfile` to `10-fabrik_modules.conf`