### PR TITLE
fix Rsyslog-Error 2077

### DIFF
--- a/jobs/docker/templates/bin/docker_ctl.erb
+++ b/jobs/docker/templates/bin/docker_ctl.erb
@@ -36,14 +36,17 @@ case $1 in
     # Enable syslog forwarding to logstash
     if [ ! -L /etc/rsyslog.d/45-docker_log_forwarding.conf ]; then
         ln -s /var/vcap/jobs/docker/config/syslog_forwarding.conf /etc/rsyslog.d/45-docker_log_forwarding.conf
-        if [ ! -e  /etc/rsyslog.d/10-fabrik_modules.conf ]; then
-            mkdir -p /var/vcap/data/docker
-            touch /var/vcap/data/docker/syslog_modules.conf
-            ln -sf /var/vcap/data/docker/syslog_modules.conf /etc/rsyslog.d/10-fabrik_modules.conf
-        fi
-        if ! grep -Fxq "\$ModLoad imtcp" /etc/rsyslog.d/10-fabrik_modules.conf ; then echo "\$ModLoad imtcp" >> /etc/rsyslog.d/10-fabrik_modules.conf ; fi
-        if ! grep -Fxq "\$ModLoad imfile" /etc/rsyslog.d/10-fabrik_modules.conf ; then echo "\$ModLoad imfile" >> /etc/rsyslog.d/10-fabrik_modules.conf ; fi
     fi
+
+    if [ ! -e  /etc/rsyslog.d/10-fabrik_modules.conf ]; then
+        mkdir -p /var/vcap/data/docker
+        touch /var/vcap/data/docker/syslog_modules.conf
+        ln -sf /var/vcap/data/docker/syslog_modules.conf /etc/rsyslog.d/10-fabrik_modules.conf
+    fi
+    if ! grep -Fxq "\$ModLoad imtcp" /etc/rsyslog.d/10-fabrik_modules.conf ; then echo "\$ModLoad imtcp" >> /etc/rsyslog.d/10-fabrik_modules.conf ; fi
+    if ! grep -Fxq "\$ModLoad imfile" /etc/rsyslog.d/10-fabrik_modules.conf ; then echo "\$ModLoad imfile" >> /etc/rsyslog.d/10-fabrik_modules.conf ; fi
+    if ! grep -Fxq "\$InputTCPServerRun 1514" /etc/rsyslog.d/10-fabrik_modules.conf ; then echo "\$InputTCPServerRun 1514" >> /etc/rsyslog.d/10-fabrik_modules.conf ; fi
+
     /usr/sbin/service rsyslog restart
 
     # Create docker data store

--- a/jobs/docker/templates/config/syslog_forwarding.conf.erb
+++ b/jobs/docker/templates/config/syslog_forwarding.conf.erb
@@ -16,9 +16,6 @@ $InputFileFacility local7
 $InputRunFileMonitor
 
 
-
-$InputTCPServerRun 514
-
 template(
     name="logstash-template-docker"
     type="string"

--- a/jobs/service-fabrik-backup-manager/templates/bin/service-fabrik-backup-manager_ctl.erb
+++ b/jobs/service-fabrik-backup-manager/templates/bin/service-fabrik-backup-manager_ctl.erb
@@ -17,15 +17,18 @@ case $1 in
     ulimit -v unlimited
 
     # Enable syslog forwarding to logstash
-    if [ ! -L /etc/rsyslog.d/52-fabrik_backup-manager_forwarding.conf ]; then
-        ln -s ${CONF_DIR}/syslog_forwarding.conf /etc/rsyslog.d/52-fabrik_backup-manager_forwarding.conf
-        if [ ! -e  /etc/rsyslog.d/10-fabrik_modules.conf ]; then
-            mkdir -p /var/vcap/data/service-fabrik-backup-manager
-            touch /var/vcap/data/service-fabrik-backup-manager/syslog_modules.conf
-            ln -sf /var/vcap/data/service-fabrik-backup-manager/syslog_modules.conf /etc/rsyslog.d/10-fabrik_modules.conf
-        fi
-        if ! grep -Fxq "\$ModLoad imtcp" /etc/rsyslog.d/10-fabrik_modules.conf ; then echo "\$ModLoad imtcp" >> /etc/rsyslog.d/10-fabrik_modules.conf ; fi
+    if [ ! -L /etc/rsyslog.d/45-fabrik_shared.conf ]; then
+        ln -s ${CONF_DIR}/syslog_forwarding.conf /etc/rsyslog.d/45-fabrik_shared.conf
     fi
+
+    if [ ! -e  /etc/rsyslog.d/10-fabrik_modules.conf ]; then
+        mkdir -p /var/vcap/data/service-fabrik-backup-manager
+        touch /var/vcap/data/service-fabrik-backup-manager/syslog_modules.conf
+        ln -sf /var/vcap/data/service-fabrik-backup-manager/syslog_modules.conf /etc/rsyslog.d/10-fabrik_modules.conf
+    fi
+    if ! grep -Fxq "\$ModLoad imtcp" /etc/rsyslog.d/10-fabrik_modules.conf ; then echo "\$ModLoad imtcp" >> /etc/rsyslog.d/10-fabrik_modules.conf ; fi
+    if ! grep -Fxq "\$InputTCPServerRun 1514" /etc/rsyslog.d/10-fabrik_modules.conf ; then echo "\$InputTCPServerRun 1514" >> /etc/rsyslog.d/10-fabrik_modules.conf ; fi
+
     /usr/sbin/service rsyslog restart
 
   # Start Service Fabrik Backup Manager

--- a/jobs/service-fabrik-backup-manager/templates/config/settings.yml.erb
+++ b/jobs/service-fabrik-backup-manager/templates/config/settings.yml.erb
@@ -17,6 +17,7 @@ production:
   username: '<%= link("broker").p('username') %>'
   password: '<%= link("broker").p('password') %>'
   broker_ip: <%= spec.ip %>
+  broker_name: '<%= broker_name %>'
   enable_service_fabrik_v2: <%= link("broker").p('enable_service_fabrik_v2') %>
   skip_ssl_validation: <%= link("broker").p('skip_ssl_validation') %>
   session_store:

--- a/jobs/service-fabrik-backup-manager/templates/config/syslog_forwarding.conf.erb
+++ b/jobs/service-fabrik-backup-manager/templates/config/syslog_forwarding.conf.erb
@@ -3,8 +3,6 @@ network = spec.networks.methods(false).first
 ip = spec.networks.send(network).ip
 %>
 
-$InputTCPServerRun 514
-
 template(
     name="logstash-template"
     type="string"

--- a/jobs/service-fabrik-bosh-manager/templates/bin/service-fabrik-bosh-manager_ctl.erb
+++ b/jobs/service-fabrik-bosh-manager/templates/bin/service-fabrik-bosh-manager_ctl.erb
@@ -17,15 +17,18 @@ case $1 in
     ulimit -v unlimited
 
     # Enable syslog forwarding to logstash
-    if [ ! -L /etc/rsyslog.d/52-fabrik_bosh-manager_forwarding.conf ]; then
-        ln -s ${CONF_DIR}/syslog_forwarding.conf /etc/rsyslog.d/52-fabrik_bosh-manager_forwarding.conf
-        if [ ! -e  /etc/rsyslog.d/10-fabrik_modules.conf ]; then
-            mkdir -p /var/vcap/data/service-fabrik-bosh-manager
-            touch /var/vcap/data/service-fabrik-bosh-manager/syslog_modules.conf
-            ln -sf /var/vcap/data/service-fabrik-bosh-manager/syslog_modules.conf /etc/rsyslog.d/10-fabrik_modules.conf
-        fi
-        if ! grep -Fxq "\$ModLoad imtcp" /etc/rsyslog.d/10-fabrik_modules.conf ; then echo "\$ModLoad imtcp" >> /etc/rsyslog.d/10-fabrik_modules.conf ; fi
+    if [ ! -L /etc/rsyslog.d/45-fabrik_shared.conf ]; then
+        ln -s ${CONF_DIR}/syslog_forwarding.conf /etc/rsyslog.d/45-fabrik_shared.conf
     fi
+
+    if [ ! -e  /etc/rsyslog.d/10-fabrik_modules.conf ]; then
+        mkdir -p /var/vcap/data/service-fabrik-bosh-manager
+        touch /var/vcap/data/service-fabrik-bosh-manager/syslog_modules.conf
+        ln -sf /var/vcap/data/service-fabrik-bosh-manager/syslog_modules.conf /etc/rsyslog.d/10-fabrik_modules.conf
+    fi
+    if ! grep -Fxq "\$ModLoad imtcp" /etc/rsyslog.d/10-fabrik_modules.conf ; then echo "\$ModLoad imtcp" >> /etc/rsyslog.d/10-fabrik_modules.conf ; fi
+    if ! grep -Fxq "\$InputTCPServerRun 1514" /etc/rsyslog.d/10-fabrik_modules.conf ; then echo "\$InputTCPServerRun 1514" >> /etc/rsyslog.d/10-fabrik_modules.conf ; fi
+
     /usr/sbin/service rsyslog restart
 
   # Start Service Fabrik bosh Manager

--- a/jobs/service-fabrik-bosh-manager/templates/config/syslog_forwarding.conf.erb
+++ b/jobs/service-fabrik-bosh-manager/templates/config/syslog_forwarding.conf.erb
@@ -3,8 +3,6 @@ network = spec.networks.methods(false).first
 ip = spec.networks.send(network).ip
 %>
 
-$InputTCPServerRun 514
-
 template(
     name="logstash-template"
     type="string"

--- a/jobs/service-fabrik-broker/templates/bin/service-fabrik-broker_ctl.erb
+++ b/jobs/service-fabrik-broker/templates/bin/service-fabrik-broker_ctl.erb
@@ -19,13 +19,16 @@ case $1 in
     # Enable syslog forwarding to logstash
     if [ ! -L /etc/rsyslog.d/49-fabrik_forwarding.conf ]; then
         ln -s /var/vcap/jobs/service-fabrik-broker/config/syslog_forwarding.conf /etc/rsyslog.d/49-fabrik_forwarding.conf
-        if [ ! -e  /etc/rsyslog.d/10-fabrik_modules.conf ]; then
-            mkdir -p /var/vcap/data/service-fabrik-broker
-            touch /var/vcap/data/service-fabrik-broker/syslog_modules.conf
-            ln -sf /var/vcap/data/service-fabrik-broker/syslog_modules.conf /etc/rsyslog.d/10-fabrik_modules.conf
-        fi
-        if ! grep -Fxq "\$ModLoad imtcp" /etc/rsyslog.d/10-fabrik_modules.conf ; then echo "\$ModLoad imtcp" >> /etc/rsyslog.d/10-fabrik_modules.conf ; fi
     fi
+
+    if [ ! -e  /etc/rsyslog.d/10-fabrik_modules.conf ]; then
+        mkdir -p /var/vcap/data/service-fabrik-broker
+        touch /var/vcap/data/service-fabrik-broker/syslog_modules.conf
+        ln -sf /var/vcap/data/service-fabrik-broker/syslog_modules.conf /etc/rsyslog.d/10-fabrik_modules.conf
+    fi
+    if ! grep -Fxq "\$ModLoad imtcp" /etc/rsyslog.d/10-fabrik_modules.conf ; then echo "\$ModLoad imtcp" >> /etc/rsyslog.d/10-fabrik_modules.conf ; fi
+    if ! grep -Fxq "\$InputTCPServerRun 1514" /etc/rsyslog.d/10-fabrik_modules.conf ; then echo "\$InputTCPServerRun 1514" >> /etc/rsyslog.d/10-fabrik_modules.conf ; fi
+
     /usr/sbin/service rsyslog restart
     
     # Start Service-Fabrik-Broker

--- a/jobs/service-fabrik-broker/templates/config/syslog_forwarding.conf.erb
+++ b/jobs/service-fabrik-broker/templates/config/syslog_forwarding.conf.erb
@@ -3,12 +3,10 @@ network = spec.networks.methods(false).first
 ip = spec.networks.send(network).ip
 %>
 
-$InputTCPServerRun 514
-
 template(
-    name="logstash-template"
+    name="logstash-template-broker"
     type="string"
     string="<%%PRI%>%TIMESTAMP:::date-rfc3339% <%= ip %> <%= p('name')%> [job=<%= name %> index=<%= index %>] %msg:::sp-if-no-1st-sp%%msg%"
 )
 
-:msg, contains , "[<%= p('name')%>]"     @@<%= p("syslog.host") %>:<%= p("syslog.port") %>;logstash-template
+:msg, contains , "[<%= p('name')%>]"     @@<%= p("syslog.host") %>:<%= p("syslog.port") %>;logstash-template-broker

--- a/jobs/service-fabrik-docker-manager/templates/bin/service-fabrik-docker-manager_ctl.erb
+++ b/jobs/service-fabrik-docker-manager/templates/bin/service-fabrik-docker-manager_ctl.erb
@@ -17,15 +17,18 @@ case $1 in
     ulimit -v unlimited
 
     # Enable syslog forwarding to logstash
-    if [ ! -L /etc/rsyslog.d/52-fabrik_docker-manager_forwarding.conf ]; then
-        ln -s ${CONF_DIR}/syslog_forwarding.conf /etc/rsyslog.d/52-fabrik_docker-manager_forwarding.conf
-        if [ ! -e  /etc/rsyslog.d/10-fabrik_modules.conf ]; then
-            mkdir -p /var/vcap/data/service-fabrik-docker-manager
-            touch /var/vcap/data/service-fabrik-docker-manager/syslog_modules.conf
-            ln -sf /var/vcap/data/service-fabrik-docker-manager/syslog_modules.conf /etc/rsyslog.d/10-fabrik_modules.conf
-        fi
-        if ! grep -Fxq "\$ModLoad imtcp" /etc/rsyslog.d/10-fabrik_modules.conf ; then echo "\$ModLoad imtcp" >> /etc/rsyslog.d/10-fabrik_modules.conf ; fi
+    if [ ! -L /etc/rsyslog.d/45-fabrik_shared.conf ]; then
+        ln -s ${CONF_DIR}/syslog_forwarding.conf /etc/rsyslog.d/45-fabrik_shared.conf
     fi
+
+    if [ ! -e  /etc/rsyslog.d/10-fabrik_modules.conf ]; then
+        mkdir -p /var/vcap/data/service-fabrik-docker-manager
+        touch /var/vcap/data/service-fabrik-docker-manager/syslog_modules.conf
+        ln -sf /var/vcap/data/service-fabrik-docker-manager/syslog_modules.conf /etc/rsyslog.d/10-fabrik_modules.conf
+    fi
+    if ! grep -Fxq "\$ModLoad imtcp" /etc/rsyslog.d/10-fabrik_modules.conf ; then echo "\$ModLoad imtcp" >> /etc/rsyslog.d/10-fabrik_modules.conf ; fi
+    if ! grep -Fxq "\$InputTCPServerRun 1514" /etc/rsyslog.d/10-fabrik_modules.conf ; then echo "\$InputTCPServerRun 1514" >> /etc/rsyslog.d/10-fabrik_modules.conf ; fi
+
     /usr/sbin/service rsyslog restart
 
   # Start Service Fabrik docker Manager

--- a/jobs/service-fabrik-docker-manager/templates/config/syslog_forwarding.conf.erb
+++ b/jobs/service-fabrik-docker-manager/templates/config/syslog_forwarding.conf.erb
@@ -3,8 +3,6 @@ network = spec.networks.methods(false).first
 ip = spec.networks.send(network).ip
 %>
 
-$InputTCPServerRun 514
-
 template(
     name="logstash-template"
     type="string"

--- a/jobs/service-fabrik-postgresqlmt-operator/templates/bin/pre_start.erb
+++ b/jobs/service-fabrik-postgresqlmt-operator/templates/bin/pre_start.erb
@@ -7,10 +7,12 @@ source /var/vcap/packages/bosh-helpers/ctl_setup.sh 'service-fabrik-postgresqlmt
 # Enable syslog forwarding to logstash
 if [ ! -L /etc/rsyslog.d/52-fabrik_postgresqlmt-operator_forwarding.conf ]; then
   ln -s ${CONF_DIR}/syslog_forwarding.conf /etc/rsyslog.d/52-fabrik_postgresqlmt-operator_forwarding.conf
-  if [ ! -e  /etc/rsyslog.d/10-fabrik_modules.conf ]; then
-    mkdir -p /var/vcap/data/service-fabrik-postgresqlmt-operator
-    touch /var/vcap/data/service-fabrik-postgresqlmt-operator/syslog_modules.conf
-    ln -sf /var/vcap/data/service-fabrik-postgresqlmt-operator/syslog_modules.conf /etc/rsyslog.d/10-fabrik_modules.conf
-  fi
-  if ! grep -Fxq "\$ModLoad imtcp" /etc/rsyslog.d/10-fabrik_modules.conf ; then echo "\$ModLoad imtcp" >> /etc/rsyslog.d/10-fabrik_modules.conf ; fi
 fi
+
+if [ ! -e  /etc/rsyslog.d/10-fabrik_modules.conf ]; then
+  mkdir -p /var/vcap/data/service-fabrik-postgresqlmt-operator
+  touch /var/vcap/data/service-fabrik-postgresqlmt-operator/syslog_modules.conf
+  ln -sf /var/vcap/data/service-fabrik-postgresqlmt-operator/syslog_modules.conf /etc/rsyslog.d/10-fabrik_modules.conf
+fi
+if ! grep -Fxq "\$ModLoad imtcp" /etc/rsyslog.d/10-fabrik_modules.conf ; then echo "\$ModLoad imtcp" >> /etc/rsyslog.d/10-fabrik_modules.conf ; fi
+if ! grep -Fxq "\$InputTCPServerRun 1514" /etc/rsyslog.d/10-fabrik_modules.conf ; then echo "\$InputTCPServerRun 1514" >> /etc/rsyslog.d/10-fabrik_modules.conf ; fi

--- a/jobs/service-fabrik-postgresqlmt-operator/templates/config/settings.yml.erb
+++ b/jobs/service-fabrik-postgresqlmt-operator/templates/config/settings.yml.erb
@@ -2,6 +2,7 @@
   log_level = "info"
   log_path = "/var/vcap/sys/log/service-fabrik-postgresqlmt-operator/service-fabrik-postgresqlmt-operator.log"
   external = link("broker").p('external')
+  broker_name = link("broker").p('name')
 %>---
 production:
   ####################
@@ -10,6 +11,7 @@ production:
   username: '<%= link("broker").p('username') %>'
   password: '<%= link("broker").p('password') %>'
   broker_ip: <%= spec.ip %>
+  broker_name: '<%= broker_name %>'
   enable_service_fabrik_v2: <%= link("broker").p('enable_service_fabrik_v2') %>
   skip_ssl_validation: <%= link("broker").p('skip_ssl_validation') %>
   log_path: <%= log_path %>

--- a/jobs/service-fabrik-postgresqlmt-operator/templates/config/syslog_forwarding.conf.erb
+++ b/jobs/service-fabrik-postgresqlmt-operator/templates/config/syslog_forwarding.conf.erb
@@ -4,12 +4,10 @@ ip = spec.networks.send(network).ip
 processname = "service-fabrik-postgresqlmt-operator"
 %>
 
-$InputTCPServerRun 514
-
 template(
-    name="logstash-template"
+    name="logstash-template-postgresqlmt"
     type="string"
     string="<%%PRI%>%TIMESTAMP:::date-rfc3339% <%= ip %> <%= processname %> [job=<%= name %> index=<%= index %>] %msg:::sp-if-no-1st-sp%%msg%"
 )
 
-:msg, contains , "[<%= processname %>]"     @@<%= link("broker").p("syslog.host") %>:<%= link("broker").p("syslog.port") %>;logstash-template
+:msg, contains , "[<%= processname %>]"     @@<%= link("broker").p("syslog.host") %>:<%= link("broker").p("syslog.port") %>;logstash-template-postgresqlmt

--- a/jobs/service-fabrik-report/templates/bin/service-fabrik-report_ctl.erb
+++ b/jobs/service-fabrik-report/templates/bin/service-fabrik-report_ctl.erb
@@ -17,15 +17,18 @@ case $1 in
     ulimit -v unlimited
 
     # Enable syslog forwarding to logstash
-    if [ ! -L /etc/rsyslog.d/51-fabrik_report_forwarding.conf ]; then
-        ln -s ${CONF_DIR}/syslog_forwarding.conf /etc/rsyslog.d/51-fabrik_report_forwarding.conf
-        if [ ! -e  /etc/rsyslog.d/10-fabrik_modules.conf ]; then
-            mkdir -p /var/vcap/data/service-fabrik-report
-            touch /var/vcap/data/service-fabrik-report/syslog_modules.conf
-            ln -sf /var/vcap/data/service-fabrik-report/syslog_modules.conf /etc/rsyslog.d/10-fabrik_modules.conf
-        fi
-        if ! grep -Fxq "\$ModLoad imtcp" /etc/rsyslog.d/10-fabrik_modules.conf ; then echo "\$ModLoad imtcp" >> /etc/rsyslog.d/10-fabrik_modules.conf ; fi
+    if [ ! -L /etc/rsyslog.d/45-fabrik_shared.conf ]; then
+        ln -s ${CONF_DIR}/syslog_forwarding.conf /etc/rsyslog.d/45-fabrik_shared.conf
     fi
+
+    if [ ! -e  /etc/rsyslog.d/10-fabrik_modules.conf ]; then
+        mkdir -p /var/vcap/data/service-fabrik-report
+        touch /var/vcap/data/service-fabrik-report/syslog_modules.conf
+        ln -sf /var/vcap/data/service-fabrik-report/syslog_modules.conf /etc/rsyslog.d/10-fabrik_modules.conf
+    fi
+    if ! grep -Fxq "\$ModLoad imtcp" /etc/rsyslog.d/10-fabrik_modules.conf ; then echo "\$ModLoad imtcp" >> /etc/rsyslog.d/10-fabrik_modules.conf ; fi
+    if ! grep -Fxq "\$InputTCPServerRun 1514" /etc/rsyslog.d/10-fabrik_modules.conf ; then echo "\$InputTCPServerRun 1514" >> /etc/rsyslog.d/10-fabrik_modules.conf ; fi
+
     /usr/sbin/service rsyslog restart
 
   # Start Service Fabrik Report

--- a/jobs/service-fabrik-report/templates/config/settings.yml.erb
+++ b/jobs/service-fabrik-report/templates/config/settings.yml.erb
@@ -17,6 +17,7 @@ production:
   ####################
   username: '<%= link("broker").p('username') %>'
   password: '<%= link("broker").p('password') %>'
+  broker_name: '<%= broker_name %>'
   enable_service_fabrik_v2: <%= link("broker").p('enable_service_fabrik_v2') %>
   skip_ssl_validation: <%= link("broker").p('skip_ssl_validation') %>
   session_store:

--- a/jobs/service-fabrik-report/templates/config/syslog_forwarding.conf.erb
+++ b/jobs/service-fabrik-report/templates/config/syslog_forwarding.conf.erb
@@ -3,8 +3,6 @@ network = spec.networks.methods(false).first
 ip = spec.networks.send(network).ip
 %>
 
-$InputTCPServerRun 514
-
 template(
     name="logstash-template"
     type="string"

--- a/jobs/service-fabrik-scheduler/templates/bin/service-fabrik-scheduler_ctl.erb
+++ b/jobs/service-fabrik-scheduler/templates/bin/service-fabrik-scheduler_ctl.erb
@@ -17,15 +17,18 @@ case $1 in
     ulimit -v unlimited
 
     # Enable syslog forwarding to logstash
-    if [ ! -L /etc/rsyslog.d/50-fabrik_job_scheduler_forwarding.conf ]; then
-        ln -s ${CONF_DIR}/syslog_forwarding.conf /etc/rsyslog.d/50-fabrik_job_scheduler_forwarding.conf
-        if [ ! -e  /etc/rsyslog.d/10-fabrik_modules.conf ]; then
-            mkdir -p /var/vcap/data/service-fabrik-scheduler
-            touch /var/vcap/data/service-fabrik-scheduler/syslog_modules.conf
-            ln -sf /var/vcap/data/service-fabrik-scheduler/syslog_modules.conf /etc/rsyslog.d/10-fabrik_modules.conf
-        fi
-        if ! grep -Fxq "\$ModLoad imtcp" /etc/rsyslog.d/10-fabrik_modules.conf ; then echo "\$ModLoad imtcp" >> /etc/rsyslog.d/10-fabrik_modules.conf ; fi
+    if [ ! -L /etc/rsyslog.d/45-fabrik_shared.conf ]; then
+        ln -s ${CONF_DIR}/syslog_forwarding.conf /etc/rsyslog.d/45-fabrik_shared.conf
     fi
+
+    if [ ! -e  /etc/rsyslog.d/10-fabrik_modules.conf ]; then
+        mkdir -p /var/vcap/data/service-fabrik-scheduler
+        touch /var/vcap/data/service-fabrik-scheduler/syslog_modules.conf
+        ln -sf /var/vcap/data/service-fabrik-scheduler/syslog_modules.conf /etc/rsyslog.d/10-fabrik_modules.conf
+    fi
+    if ! grep -Fxq "\$ModLoad imtcp" /etc/rsyslog.d/10-fabrik_modules.conf ; then echo "\$ModLoad imtcp" >> /etc/rsyslog.d/10-fabrik_modules.conf ; fi
+    if ! grep -Fxq "\$InputTCPServerRun 1514" /etc/rsyslog.d/10-fabrik_modules.conf ; then echo "\$InputTCPServerRun 1514" >> /etc/rsyslog.d/10-fabrik_modules.conf ; fi
+
     /usr/sbin/service rsyslog restart
 
 	# Start Service Fabrik Job Scheduler

--- a/jobs/service-fabrik-scheduler/templates/config/syslog_forwarding.conf.erb
+++ b/jobs/service-fabrik-scheduler/templates/config/syslog_forwarding.conf.erb
@@ -3,8 +3,6 @@ network = spec.networks.methods(false).first
 ip = spec.networks.send(network).ip
 %>
 
-$InputTCPServerRun 514
-
 template(
     name="logstash-template"
     type="string"

--- a/jobs/service-fabrik-serviceflow-manager/templates/bin/pre_start.erb
+++ b/jobs/service-fabrik-serviceflow-manager/templates/bin/pre_start.erb
@@ -5,12 +5,14 @@ set -e # exit immediately if a simple command exits with a non-zero status
 source /var/vcap/packages/bosh-helpers/ctl_setup.sh 'service-fabrik-serviceflow-manager'
 
 # Enable syslog forwarding to logstash
-if [ ! -L /etc/rsyslog.d/53-fabrik_serviceflow-manager_forwarding.conf ]; then
-  ln -s ${CONF_DIR}/syslog_forwarding.conf /etc/rsyslog.d/53-fabrik_serviceflow-manager_forwarding.conf
-  if [ ! -e  /etc/rsyslog.d/10-fabrik_modules.conf ]; then
-    mkdir -p /var/vcap/data/service-fabrik-serviceflow-manager
-    touch /var/vcap/data/service-fabrik-serviceflow-manager/syslog_modules.conf
-    ln -sf /var/vcap/data/service-fabrik-serviceflow-manager/syslog_modules.conf /etc/rsyslog.d/10-fabrik_modules.conf
-  fi
-  if ! grep -Fxq "\$ModLoad imtcp" /etc/rsyslog.d/10-fabrik_modules.conf ; then echo "\$ModLoad imtcp" >> /etc/rsyslog.d/10-fabrik_modules.conf ; fi
+if [ ! -L /etc/rsyslog.d/45-fabrik_shared.conf ]; then
+  ln -s ${CONF_DIR}/syslog_forwarding.conf /etc/rsyslog.d/45-fabrik_shared.conf
 fi
+
+if [ ! -e  /etc/rsyslog.d/10-fabrik_modules.conf ]; then
+  mkdir -p /var/vcap/data/service-fabrik-serviceflow-manager
+  touch /var/vcap/data/service-fabrik-serviceflow-manager/syslog_modules.conf
+  ln -sf /var/vcap/data/service-fabrik-serviceflow-manager/syslog_modules.conf /etc/rsyslog.d/10-fabrik_modules.conf
+fi
+if ! grep -Fxq "\$ModLoad imtcp" /etc/rsyslog.d/10-fabrik_modules.conf ; then echo "\$ModLoad imtcp" >> /etc/rsyslog.d/10-fabrik_modules.conf ; fi
+if ! grep -Fxq "\$InputTCPServerRun 1514" /etc/rsyslog.d/10-fabrik_modules.conf ; then echo "\$InputTCPServerRun 1514" >> /etc/rsyslog.d/10-fabrik_modules.conf ; fi

--- a/jobs/service-fabrik-serviceflow-manager/templates/config/settings.yml.erb
+++ b/jobs/service-fabrik-serviceflow-manager/templates/config/settings.yml.erb
@@ -13,6 +13,7 @@ production:
   # GENERAL SETTINGS #
   ####################
   broker_ip: <%= spec.ip %>
+  broker_name: '<%= broker_name %>'
   log_path: <%= log_path %>
   log_level: <%= link("broker").p('log_level') %>
 

--- a/jobs/service-fabrik-serviceflow-manager/templates/config/syslog_forwarding.conf.erb
+++ b/jobs/service-fabrik-serviceflow-manager/templates/config/syslog_forwarding.conf.erb
@@ -3,8 +3,6 @@ network = spec.networks.methods(false).first
 ip = spec.networks.send(network).ip
 %>
 
-$InputTCPServerRun 514
-
 template(
     name="logstash-template"
     type="string"

--- a/jobs/service-fabrik-virtualhost-manager/templates/bin/service-fabrik-virtualhost-manager_ctl.erb
+++ b/jobs/service-fabrik-virtualhost-manager/templates/bin/service-fabrik-virtualhost-manager_ctl.erb
@@ -17,15 +17,18 @@ case $1 in
     ulimit -v unlimited
 
     # Enable syslog forwarding to logstash
-    if [ ! -L /etc/rsyslog.d/52-fabrik_virtualhost-manager_forwarding.conf ]; then
-        ln -s ${CONF_DIR}/syslog_forwarding.conf /etc/rsyslog.d/52-fabrik_virtualhost-manager_forwarding.conf
-        if [ ! -e  /etc/rsyslog.d/10-fabrik_modules.conf ]; then
-            mkdir -p /var/vcap/data/service-fabrik-virtualhost-manager
-            touch /var/vcap/data/service-fabrik-virtualhost-manager/syslog_modules.conf
-            ln -sf /var/vcap/data/service-fabrik-virtualhost-manager/syslog_modules.conf /etc/rsyslog.d/10-fabrik_modules.conf
-        fi
-        if ! grep -Fxq "\$ModLoad imtcp" /etc/rsyslog.d/10-fabrik_modules.conf ; then echo "\$ModLoad imtcp" >> /etc/rsyslog.d/10-fabrik_modules.conf ; fi
+    if [ ! -L /etc/rsyslog.d/45-fabrik_shared.conf ]; then
+        ln -s ${CONF_DIR}/syslog_forwarding.conf /etc/rsyslog.d/45-fabrik_shared.conf
     fi
+
+    if [ ! -e  /etc/rsyslog.d/10-fabrik_modules.conf ]; then
+        mkdir -p /var/vcap/data/service-fabrik-virtualhost-manager
+        touch /var/vcap/data/service-fabrik-virtualhost-manager/syslog_modules.conf
+        ln -sf /var/vcap/data/service-fabrik-virtualhost-manager/syslog_modules.conf /etc/rsyslog.d/10-fabrik_modules.conf
+    fi
+    if ! grep -Fxq "\$ModLoad imtcp" /etc/rsyslog.d/10-fabrik_modules.conf ; then echo "\$ModLoad imtcp" >> /etc/rsyslog.d/10-fabrik_modules.conf ; fi
+    if ! grep -Fxq "\$InputTCPServerRun 1514" /etc/rsyslog.d/10-fabrik_modules.conf ; then echo "\$InputTCPServerRun 1514" >> /etc/rsyslog.d/10-fabrik_modules.conf ; fi
+
     /usr/sbin/service rsyslog restart
 
   # Start Service Fabrik virtualhost Manager

--- a/jobs/service-fabrik-virtualhost-manager/templates/config/settings.yml.erb
+++ b/jobs/service-fabrik-virtualhost-manager/templates/config/settings.yml.erb
@@ -17,6 +17,7 @@ production:
   username: '<%= link("broker").p('username') %>'
   password: '<%= link("broker").p('password') %>'
   broker_ip: <%= spec.ip %>
+  broker_name: '<%= broker_name %>'
   enable_service_fabrik_v2: <%= link("broker").p('enable_service_fabrik_v2') %>
   skip_ssl_validation: <%= link("broker").p('skip_ssl_validation') %>
   session_store:

--- a/jobs/service-fabrik-virtualhost-manager/templates/config/syslog_forwarding.conf.erb
+++ b/jobs/service-fabrik-virtualhost-manager/templates/config/syslog_forwarding.conf.erb
@@ -3,8 +3,6 @@ network = spec.networks.methods(false).first
 ip = spec.networks.send(network).ip
 %>
 
-$InputTCPServerRun 514
-
 template(
     name="logstash-template"
     type="string"

--- a/jobs/swarm_manager/templates/bin/swarm_manager_ctl
+++ b/jobs/swarm_manager/templates/bin/swarm_manager_ctl
@@ -15,14 +15,17 @@ case $1 in
     # Enable syslog forwarding to logstash
     if [ ! -L /etc/rsyslog.d/45-swarm_manager_forwarding.conf ]; then
         ln -s /var/vcap/jobs/swarm_manager/config/syslog_forwarding.conf /etc/rsyslog.d/45-swarm_manager_forwarding.conf
-        if [ ! -e  /etc/rsyslog.d/10-fabrik_modules.conf ]; then
-            mkdir -p /var/vcap/data/swarm_manager
-            touch /var/vcap/data/swarm_manager/syslog_modules.conf
-            ln -sf /var/vcap/data/swarm_manager/syslog_modules.conf /etc/rsyslog.d/10-fabrik_modules.conf
-        fi
-        if ! grep -Fxq "\$ModLoad imtcp" /etc/rsyslog.d/10-fabrik_modules.conf ; then echo "\$ModLoad imtcp" >> /etc/rsyslog.d/10-fabrik_modules.conf ; fi
-        if ! grep -Fxq "\$ModLoad imfile" /etc/rsyslog.d/10-fabrik_modules.conf ; then echo "\$ModLoad imfile" >> /etc/rsyslog.d/10-fabrik_modules.conf ; fi
     fi
+
+    if [ ! -e  /etc/rsyslog.d/10-fabrik_modules.conf ]; then
+        mkdir -p /var/vcap/data/swarm_manager
+        touch /var/vcap/data/swarm_manager/syslog_modules.conf
+        ln -sf /var/vcap/data/swarm_manager/syslog_modules.conf /etc/rsyslog.d/10-fabrik_modules.conf
+    fi
+    if ! grep -Fxq "\$ModLoad imtcp" /etc/rsyslog.d/10-fabrik_modules.conf ; then echo "\$ModLoad imtcp" >> /etc/rsyslog.d/10-fabrik_modules.conf ; fi
+    if ! grep -Fxq "\$ModLoad imfile" /etc/rsyslog.d/10-fabrik_modules.conf ; then echo "\$ModLoad imfile" >> /etc/rsyslog.d/10-fabrik_modules.conf ; fi
+    if ! grep -Fxq "\$InputTCPServerRun 1514" /etc/rsyslog.d/10-fabrik_modules.conf ; then echo "\$InputTCPServerRun 1514" >> /etc/rsyslog.d/10-fabrik_modules.conf ; fi
+
     set +e
     /usr/sbin/service rsyslog restart
     set -e

--- a/jobs/swarm_manager/templates/config/syslog_forwarding.conf.erb
+++ b/jobs/swarm_manager/templates/config/syslog_forwarding.conf.erb
@@ -15,8 +15,6 @@ $InputFileSeverity error
 $InputFileFacility local7
 $InputRunFileMonitor
 
-$InputTCPServerRun 514
-
 template(
     name="logstash-template-swarm"
     type="string"


### PR DESCRIPTION
# Description

We are receiving Error-Messages regarding the Service-Fabrik.

```
Could not create tcp listener, ignoring port 514 bind-address (null). [v8.1901.0 try https://www.rsyslog.com/e/2077 ]
```

The syslog configuration currently will attempt to create a TCP-Listener for Port 514. 

https://github.com/cloudfoundry-incubator/service-fabrik-boshrelease/blob/master/jobs/service-fabrik-broker/templates/config/syslog_forwarding.conf.erb#L6

However, this port 514 is located in the privileged area for which higher privileges are needed.
For safety reasons, the new version of Rsyslog will drop the privileges to a standard User. 
See changelog Rsyslog 4.1.1

> Dropping Privileges 
> Starting with 4.1.1, rsyslogd provides the ability to drop privileges by impersonating as another user and/or group after startup.
> 
> Please note that due to POSIX standards, rsyslogd always needs to start up as root if there is a listener who must bind to a network port below 1024. For example, the UDP listener usually needs to listen to 514 and as such rsyslogd needs to start up as root.
> 
> If you do not need this functionality, you can start rsyslog directly as an ordinary user. That is probably the safest way of operations. However, if a startup as root is required, you can use the $PrivDropToGroup and $PrivDropToUser config directives to specify a group and/or user that rsyslogd should drop to after initialization. Once this happend, the daemon runs without high privileges (depending, of course, on the permissions of the user account you specified).

It works at the moment, because the port is already created in the master configuration (/etc/Rsyslog.conf) before the permissions are dropped.

https://github.com/rsyslog/rsyslog/blob/69f8e1d1f7fe62fd2c5f38a81d4102a9a62d1722/grammar/debian.conf#L21

This PR will reallocate the Listening-Port from 514 to 1514.

## Changelog:
* Combined configuration files with the same content
* Moved TCP Port from 514 to 1514 to avoid conflict with the restricted area
* TCP Server startup moved to 10-fabrik_modules.conf to avoid multiple call
* Fixed a naming Conflict with the Forwarding-Templates of service-fabrik-broker and service-fabrik-postgresqlmt
* Fixed undefined broker-name

NOTE: Two-part PR
Please only merge this PR if the second PR ( https://github.com/cloudfoundry-incubator/service-fabrik-broker/pull/584 ) can also be merged.

- [x] This pull request is ready to be merged
- [x] The depending pull request is ready to be merged
