### PR TITLE
Modifying health check script

### DIFF
--- a/jobs/keepalived/templates/bin/notify.sh.erb
+++ b/jobs/keepalived/templates/bin/notify.sh.erb
@@ -6,3 +6,4 @@ NAME=$2
 STATE=$3
 
 echo $STATE > /var/vcap/sys/run/keepalived/keepalive.$TYPE.$NAME.state
+echo $STATE > /var/vcap/jobs/service-fabrik-broker/bin/keepalive.$TYPE.$NAME.state

--- a/jobs/keepalived/templates/bin/notify.sh.erb
+++ b/jobs/keepalived/templates/bin/notify.sh.erb
@@ -6,4 +6,3 @@ NAME=$2
 STATE=$3
 
 echo $STATE > /var/vcap/sys/run/keepalived/keepalive.$TYPE.$NAME.state
-echo $STATE > /var/vcap/jobs/service-fabrik-broker/bin/keepalive.$TYPE.$NAME.state

--- a/jobs/service-fabrik-broker/templates/bin/health_check.erb
+++ b/jobs/service-fabrik-broker/templates/bin/health_check.erb
@@ -8,7 +8,7 @@
 
 ha_enabled=<%= p('ha_enabled') %>
 if [[ "$ha_enabled" == "true" ]]; then
-  vm_state="$(cat /var/vcap/sys/run/keepalived/keepalive.*.state)"
+  vm_state="$(cat /var/vcap/jobs/service-fabrik-broker/bin/keepalive.*.state)"
   if [[ "$vm_state" != "MASTER" ]]; then
     exit 1
   fi

--- a/jobs/service-fabrik-broker/templates/bin/health_check.erb
+++ b/jobs/service-fabrik-broker/templates/bin/health_check.erb
@@ -6,14 +6,6 @@
 # Also to avoid swamping of Nats server with route registration requests
 # we will return success from here only if the current host is MASTER
 
-ha_enabled=<%= p('ha_enabled') %>
-if [[ "$ha_enabled" == "true" ]]; then
-  vm_state="$(cat /var/vcap/jobs/service-fabrik-broker/bin/keepalive.*.state)"
-  if [[ "$vm_state" != "MASTER" ]]; then
-    exit 1
-  fi
-fi
-
 # check if internal IP is accessible
 nc -z <%= p('internal.ip') %> <%= p('external.port') %>
 

--- a/jobs/service-fabrik-broker/templates/bin/health_check.erb
+++ b/jobs/service-fabrik-broker/templates/bin/health_check.erb
@@ -1,22 +1,28 @@
 #!/bin/bash
 
-# Checking if HA setup needs to be done or not.
+# With usage of 'host' property for IP address 
+# (check this: https://github.com/cloudfoundry/routing-release/pull/111) for route-registrar, 
+# only check needed is whether internal ip is reachable on both ports.
+# Also to avoid swamping of Nats server with route registration requests
+# we will return success from here only if the current host is MASTER
+
 ha_enabled=<%= p('ha_enabled') %>
-if [[ "$ha_enabled" == "true"  ]]; then
-  vm_state=$(/var/vcap/jobs/keepalived/bin/get_keepalived_state.sh)
-  if [[ "$vm_state" != "up" ]]; then
+if [[ "$ha_enabled" == "true" ]]; then
+  vm_state="$(cat /var/vcap/sys/run/keepalived/keepalive.*.state)"
+  if [[ "$vm_state" != "MASTER" ]]; then
     exit 1
   fi
 fi
 
-nc -z <%= spec.ip %> <%= p('external.port') %>
+# check if internal IP is accessible
+nc -z <%= p('internal.ip') %> <%= p('external.port') %>
 
 # http://www.consul.io/docs/agent/checks.html
 if [ $? -ne 0 ]; then
   exit 2 # Exit higher than 1 to ensure service is registered as 'critical'
 fi
 
-nc -z <%= spec.ip %> <%= p('internal.port') %>
+nc -z <%= p('internal.ip') %> <%= p('internal.port') %>
 
 # http://www.consul.io/docs/agent/checks.html
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
* It is planned to adopt `host` property for specifying IP address in route-registrar properties (refer [here](https://github.com/cloudfoundry/routing-release/pull/111)). With it's usage, it makes sense to perform health check on the the IP given by `host` property instead of obtaining it from underlying VM. This PR makes these changes in health-check script.