### PR TITLE
Adding config for ArchiveMeteredEvents job

### DIFF
--- a/jobs/service-fabrik-scheduler/spec
+++ b/jobs/service-fabrik-scheduler/spec
@@ -47,6 +47,8 @@ provides:
   - system_jobs.dbcollection_reaper.event_detail.retention_in_days
   - system_jobs.meter_instance.interval
   - system_jobs.meter_instance.enabled
+  - system_jobs.archive_metered_events.interval
+  - system_jobs.archive_metered_events.job_data.events_to_patch
 
 consumes:
 - name: broker
@@ -147,3 +149,9 @@ properties:
   system_jobs.meter_instance.enabled:
     description: "true if metering is enabled"
     default: false
+  system_jobs.archive_metered_events.interval:
+    description: "Cron expression defining schedule interval for archive_metered_events job"
+    default: 0 */6 * * *
+  system_jobs.archive_metered_events.job_data.events_to_patch:
+    description: "Number of events to patch in one job run"
+    default: 100

--- a/jobs/service-fabrik-scheduler/spec
+++ b/jobs/service-fabrik-scheduler/spec
@@ -151,7 +151,7 @@ properties:
     default: false
   system_jobs.archive_metered_events.interval:
     description: "Cron expression defining schedule interval for archive_metered_events job"
-    default: 0 */6 * * *
+    default: 0 */4 * * *
   system_jobs.archive_metered_events.job_data.events_to_patch:
     description: "Number of events to patch in one job run"
-    default: 100
+    default: 500

--- a/jobs/service-fabrik-scheduler/templates/config/settings.yml.erb
+++ b/jobs/service-fabrik-scheduler/templates/config/settings.yml.erb
@@ -165,6 +165,12 @@ production:
         type: MeterInstance
         interval: <%= p('system_jobs.meter_instance.interval') %>
         enabled: true
+      - name: 'Archive_Metered_Instance'
+        type: ArchiveMeteredEvents
+        interval: <%= p('system_jobs.archive_metered_events.interval') %>
+        job_data:
+          events_to_patch: <%= p('system_jobs.archive_metered_events.job_data.events_to_patch') %>
+
 
   #######################
   # MONITORING SETTINGS #

--- a/jobs/service-fabrik-scheduler/templates/config/settings.yml.erb
+++ b/jobs/service-fabrik-scheduler/templates/config/settings.yml.erb
@@ -165,7 +165,7 @@ production:
         type: MeterInstance
         interval: <%= p('system_jobs.meter_instance.interval') %>
         enabled: true
-      - name: 'Archive_Metered_Instance'
+      - name: 'Archive_Metered_Events'
         type: ArchiveMeteredEvents
         interval: <%= p('system_jobs.archive_metered_events.interval') %>
         job_data:


### PR DESCRIPTION
* This PR adds configuration for `ArchiveMeteredEvents` job in `service-fabrik-scheduler` bosh job.
* There are two config parameters: `interval` and `events_to_patch`.