### PR TITLE
Set session_store and log path based on the job name

### DIFF
--- a/jobs/service-fabrik-backup-manager/templates/config/settings.yml.erb
+++ b/jobs/service-fabrik-backup-manager/templates/config/settings.yml.erb
@@ -21,7 +21,7 @@ production:
   enable_service_fabrik_v2: <%= link("broker").p('enable_service_fabrik_v2') %>
   skip_ssl_validation: <%= link("broker").p('skip_ssl_validation') %>
   session_store:
-    path: <%= "/var/vcap/store/#{broker_name}/session" %>
+    path: "/var/vcap/store/service-fabrik-backup-manager/session"
   log_path: <%= log_path %>
   log_level: <%= link("broker").p('log_level') %>
   enable_circuit_breaker: <%= link("broker").p('enable_circuit_breaker') %>

--- a/jobs/service-fabrik-bosh-manager/templates/config/settings.yml.erb
+++ b/jobs/service-fabrik-bosh-manager/templates/config/settings.yml.erb
@@ -24,7 +24,7 @@ production:
   enable_service_fabrik_v2: <%= link("broker").p('enable_service_fabrik_v2') %>
   skip_ssl_validation: <%= link("broker").p('skip_ssl_validation') %>
   session_store:
-    path: <%= "/var/vcap/store/#{broker_name}/session" %>
+    path: "/var/vcap/store/service-fabrik-bosh-manager/session"
   log_path: <%= log_path %>
   log_level: <%= link("broker").p('log_level') %>
   sys_log_level: <%= link("broker").p('sys_log_level') %>

--- a/jobs/service-fabrik-broker/templates/config/settings.yml.erb
+++ b/jobs/service-fabrik-broker/templates/config/settings.yml.erb
@@ -6,7 +6,7 @@
   end
 
   broker_name = p('name')
-  log_path = "/var/vcap/sys/log/#{broker_name}/#{broker_name}.log"
+  log_path = "/var/vcap/sys/log/service-fabrik-broker/service-fabrik-broker.log"
   networks = ostruct_to_hash(spec.networks)
   default_ip = networks.values.find { |net| net.has_key?(:default) }[:ip]
   external = p('external')
@@ -25,7 +25,7 @@ production:
   enable_service_fabrik_v2: <%= p('enable_service_fabrik_v2') %>
   skip_ssl_validation: <%= p('skip_ssl_validation') %>
   session_store:
-    path: <%= "/var/vcap/store/#{broker_name}/session" %>
+    path: "/var/vcap/store/service-fabrik-broker/session"
   log_path: <%= log_path %>
   log_level: <%= p('log_level') %>
   sys_log_level: <%= p('sys_log_level') %>

--- a/jobs/service-fabrik-deployment-hooks/templates/config/settings.yml.erb
+++ b/jobs/service-fabrik-deployment-hooks/templates/config/settings.yml.erb
@@ -11,7 +11,7 @@ production:
   password: '<%= p('password') %>'
   skip_ssl_validation: <%= p('skip_ssl_validation') %>
   session_store:
-    path: <%= "/var/vcap/store/#{broker_name}/session" %>
+    path: "/var/vcap/store/service-fabrik-deployment-hooks/session"
   log_path: <%= log_path %>
   log_level: <%= p('log_level') %>
   enable_circuit_breaker: <%= p('enable_circuit_breaker') %>

--- a/jobs/service-fabrik-scheduler/templates/config/settings.yml.erb
+++ b/jobs/service-fabrik-scheduler/templates/config/settings.yml.erb
@@ -27,7 +27,7 @@ production:
   enable_service_fabrik_v2: <%= link("broker").p('enable_service_fabrik_v2') %>
   skip_ssl_validation: <%= link("broker").p('skip_ssl_validation') %>
   session_store:
-    path: <%= "/var/vcap/store/#{broker_name}/session" %>
+    path: "/var/vcap/store/service-fabrik-scheduler/session"
   log_path: <%= log_path %>
   log_level: <%= link("broker").p('log_level') %>
   sys_log_level: <%= link("broker").p('sys_log_level') %>

--- a/jobs/service-fabrik-virtualhost-manager/templates/config/settings.yml.erb
+++ b/jobs/service-fabrik-virtualhost-manager/templates/config/settings.yml.erb
@@ -21,7 +21,7 @@ production:
   enable_service_fabrik_v2: <%= link("broker").p('enable_service_fabrik_v2') %>
   skip_ssl_validation: <%= link("broker").p('skip_ssl_validation') %>
   session_store:
-    path: <%= "/var/vcap/store/#{broker_name}/session" %>
+    path: "/var/vcap/store/service-fabrik-virtualhost-manager/session"
   log_path: <%= log_path %>
   log_level: <%= link("broker").p('log_level') %>
   enable_circuit_breaker: <%= link("broker").p('enable_circuit_breaker') %>


### PR DESCRIPTION
The service fabrik currently selects the session store and log path based on the broker name. This does not work if the broker has a different name than service-fabrik-broker, because the file permissions are not setup correctly. Also a job should work the store directory with the same name as the job name.

The behavioral change is that
- it is not possible to register the service fabrik under a different name and still use the admin api
- now all store the session into the `/var/vcap/<job>/sessions` instead of the `/var/vcap/service-fabrik-broker/sessions` directory, which also seems to be right (otherwise the service fabrik jobs can't be deployed on different VMs if they use the session store)