### PR TITLE
Add setting riemann.enabled to make Riemann optional

### DIFF
--- a/jobs/service-fabrik-backup-manager/templates/config/settings.yml.erb
+++ b/jobs/service-fabrik-backup-manager/templates/config/settings.yml.erb
@@ -98,6 +98,7 @@ production:
       tags: ['security', 'unauthorized']
       include_response_body: <%= link("broker").p('monitoring.unauthorized.include_response_body') %>
   riemann:
+    enabled: <%= link("broker").p('riemann.enabled') %>
     host: <%= link("broker").p('riemann.host') %>
     port: <%= link("broker").p('riemann.port') %>
     protocol : tcp

--- a/jobs/service-fabrik-bosh-manager/templates/config/settings.yml.erb
+++ b/jobs/service-fabrik-bosh-manager/templates/config/settings.yml.erb
@@ -197,6 +197,7 @@ production:
       tags: ['security', 'unauthorized']
       include_response_body: <%= link("broker").p('monitoring.unauthorized.include_response_body') %>
   riemann:
+    enabled: <%= link("broker").p('riemann.enabled') %>
     host: <%= link("broker").p('riemann.host') %>
     port: <%= link("broker").p('riemann.port') %>
     protocol : tcp

--- a/jobs/service-fabrik-broker/spec
+++ b/jobs/service-fabrik-broker/spec
@@ -66,6 +66,7 @@ provides:
   - monitoring.include_response_body
   - monitoring.events_logged_in_db
   - monitoring.unauthorized.include_response_body
+  - riemann.enabled
   - riemann.show_errors
   - riemann.log_additional_event
   - riemann.http_status_codes_to_be_skipped
@@ -357,6 +358,9 @@ properties:
     description: "Determines if the unauthorized event should contain the HTTP method response while logging"
     default: true
 
+  riemann.enabled:
+    description: "Determines whether events should be forwarded to Riemann"
+    default: true
   riemann.host:
     description: "Riemann Host IP"
     default: "10.1.3.1"

--- a/jobs/service-fabrik-broker/templates/config/settings.yml.erb
+++ b/jobs/service-fabrik-broker/templates/config/settings.yml.erb
@@ -208,6 +208,7 @@ production:
       tags: ['security', 'unauthorized']
       include_response_body: <%= p('monitoring.unauthorized.include_response_body') %>
   riemann:
+    enabled: <%= p('riemann.enabled') %>
     host: <%= p('riemann.host') %>
     port: <%= p('riemann.port') %>
     protocol : tcp

--- a/jobs/service-fabrik-docker-manager/templates/config/settings.yml.erb
+++ b/jobs/service-fabrik-docker-manager/templates/config/settings.yml.erb
@@ -198,6 +198,7 @@ production:
       tags: ['security', 'unauthorized']
       include_response_body: <%= link("broker").p('monitoring.unauthorized.include_response_body') %>
   riemann:
+    enabled: <%= link("broker").p('riemann.enabled') %>
     host: <%= link("broker").p('riemann.host') %>
     port: <%= link("broker").p('riemann.port') %>
     protocol : tcp

--- a/jobs/service-fabrik-report/templates/config/settings.yml.erb
+++ b/jobs/service-fabrik-report/templates/config/settings.yml.erb
@@ -99,6 +99,7 @@ production:
       tags: ['security', 'unauthorized']
       include_response_body: <%= link("broker").p('monitoring.unauthorized.include_response_body') %>
   riemann:
+    enabled: <%= link("broker").p('riemann.enabled') %>
     host: <%= link("broker").p('riemann.host') %>
     port: <%= link("broker").p('riemann.port') %>
     protocol : tcp

--- a/jobs/service-fabrik-scheduler/templates/config/settings.yml.erb
+++ b/jobs/service-fabrik-scheduler/templates/config/settings.yml.erb
@@ -193,6 +193,7 @@ production:
       tags: ['security', 'unauthorized']
       include_response_body: <%= link("broker").p('monitoring.unauthorized.include_response_body') %>
   riemann:
+    enabled: <%= link("broker").p('riemann.enabled') %>
     host: <%= link("broker").p('riemann.host') %>
     port: <%= link("broker").p('riemann.port') %>
     protocol : tcp


### PR DESCRIPTION
This adds the setting `riemann.enabled` with the default value `true`, which sets the corresponding setting into the settings.yml file.

This goal of this PR is to add a setting to make Riemann logging optional, i.e. remove the dependency to Riemann (optional instead of required).

The corresponding changes in the broker code: https://github.com/cloudfoundry-incubator/service-fabrik-broker/pull/650