### PR TITLE
Add meter webhook based on a different flag

### DIFF
--- a/jobs/service-fabrik-broker/spec
+++ b/jobs/service-fabrik-broker/spec
@@ -116,6 +116,7 @@ provides:
   - multi_az_enabled
   - ha_enabled
   - metering.enabled
+  - metering.create_metering_events
   - metering.binding.clientid
   - metering.binding.clientsecret
   - metering.binding.token_url
@@ -429,6 +430,9 @@ properties:
   metering.enabled:
     description: "True if metering in enabled"
     default: false
+  metering.create_metering_events:
+    description: "Create sfevents crds"
+    default: true
   metering.binding.clientid:
     description: "The client id provided by the metering service"
   metering.binding.clientsecret:

--- a/jobs/webhooks/templates/bin/post-start.erb
+++ b/jobs/webhooks/templates/bin/post-start.erb
@@ -33,7 +33,7 @@ fi
 
 
 echo "Trying to update the metering webhook configuration"
-METERING_ENABLED=<%= link('broker').p('metering.enabled') %>
+METERING_ENABLED=<%= link('broker').p('metering.create_metering_events') %>
 
 if [[ $METERING_ENABLED == true ]] ; then
   RESPONSE=$(curl                                                        \
@@ -56,7 +56,7 @@ if [[ $METERING_ENABLED == true ]] ; then
      --data "@$CONFIG_PATH/metering_webhooks.json"
   fi
 else
-  echo "Metering is disabled, removing webhook configuration"
+  echo "Creation of sfevents is disabled, removing webhook configuration"
   RESPONSE=$(curl                                                        \
       -sk                                                                \
       --header "Content-Type: application/json"                          \

--- a/jobs/webhooks/templates/bin/post-start.erb
+++ b/jobs/webhooks/templates/bin/post-start.erb
@@ -33,23 +33,37 @@ fi
 
 
 echo "Trying to update the metering webhook configuration"
+METERING_ENABLED=<%= link('broker').p('metering.enabled') %>
 
-RESPONSE=$(curl                                                        \
-    -sk                                                                \
-    --header "Content-Type: application/merge-patch+json"              \
-    --cert $CONFIG_PATH/client-cert.pem                                \
-    --key $CONFIG_PATH/client-key.pem "${HOST_PATH}/metering-webhooks" \
-    -X PATCH                                                           \
-    --data "@$CONFIG_PATH/metering_webhooks.json")
-RESPONSE_CODE=$(echo $RESPONSE | $JQ -r .'code')
-echo "Response code of the patch is $RESPONSE_CODE"
-if [[ "$RESPONSE_CODE" == "404" ]]; then
-    echo "creating the metering webhook"
-    curl                                             \
-    -sk                                              \
-    --header "Content-Type: application/json"        \
-    --cert $CONFIG_PATH/client-cert.pem              \
-    --key $CONFIG_PATH/client-key.pem "${HOST_PATH}" \
-    -X POST                                          \
-    --data "@$CONFIG_PATH/metering_webhooks.json"
+if [[ $METERING_ENABLED == true ]] ; then
+  RESPONSE=$(curl                                                        \
+      -sk                                                                \
+      --header "Content-Type: application/merge-patch+json"              \
+      --cert $CONFIG_PATH/client-cert.pem                                \
+      --key $CONFIG_PATH/client-key.pem "${HOST_PATH}/metering-webhooks" \
+      -X PATCH                                                           \
+      --data "@$CONFIG_PATH/metering_webhooks.json")
+  RESPONSE_CODE=$(echo $RESPONSE | $JQ -r .'code')
+  echo "Response code of the patch is $RESPONSE_CODE"
+  if [[ "$RESPONSE_CODE" == "404" ]]; then
+     echo "creating the metering webhook"
+     curl                                             \
+     -sk                                              \
+     --header "Content-Type: application/json"        \
+     --cert $CONFIG_PATH/client-cert.pem              \
+     --key $CONFIG_PATH/client-key.pem "${HOST_PATH}" \
+     -X POST                                          \
+     --data "@$CONFIG_PATH/metering_webhooks.json"
+  fi
+else
+  echo "Metering is disabled, removing webhook configuration"
+  RESPONSE=$(curl                                                        \
+      -sk                                                                \
+      --header "Content-Type: application/json"                          \
+      --cert $CONFIG_PATH/client-cert.pem                                \
+      --key $CONFIG_PATH/client-key.pem "${HOST_PATH}/metering-webhooks" \
+      -X DELETE                                                          \
+      --data "@$CONFIG_PATH/metering_webhooks.json")
+  RESPONSE_CODE=$(echo $RESPONSE | $JQ -r .'code')
+  echo "Response code of the delete is $RESPONSE_CODE"
 fi


### PR DESCRIPTION
* Reverts cloudfoundry-incubator/service-fabrik-boshrelease#178
* Uses a different flag for metering webhook enablement.