### PR TITLE
Ensuring CRD registration happens only once.

### DIFF
--- a/jobs/service-fabrik-apiserver/spec
+++ b/jobs/service-fabrik-apiserver/spec
@@ -3,6 +3,8 @@ name: service-fabrik-apiserver
 
 packages:
 - apiserver
+- interoperator
+- kubectl
 
 templates:
   bin/ensure_apiserver_healthy.erb: bin/ensure_apiserver_healthy

--- a/jobs/service-fabrik-apiserver/templates/bin/post-start.erb
+++ b/jobs/service-fabrik-apiserver/templates/bin/post-start.erb
@@ -11,3 +11,9 @@ else
   echo "Waited for ${TIMEOUT}s, but Apiserver is still not healthy"
   exit 1
 fi
+
+export KUBECONFIG=/var/vcap/jobs/service-fabrik-apiserver/config/kubeconfig
+<% if spec.bootstrap == true %>
+echo "Applying CRDs after creating the apiserver process starts-up"
+/var/vcap/packages/kubectl/bin/kubectl apply -f /var/vcap/packages/interoperator/config/crd/bases
+<% end %>

--- a/jobs/service-fabrik-interoperator/templates/bin/pre_start.erb
+++ b/jobs/service-fabrik-interoperator/templates/bin/pre_start.erb
@@ -4,7 +4,6 @@
 
 export KUBECONFIG=/var/vcap/jobs/service-fabrik-interoperator/config/kubeconfig.yaml
 <% if spec.bootstrap == true %>
-echo "Applying CRDs before creating the interoperator process"
-/var/vcap/packages/kubectl/bin/kubectl apply -f /var/vcap/packages/interoperator/config/crd/bases
+echo "Creating SFCluster CR before creating the interoperator process"
 /var/vcap/packages/kubectl/bin/kubectl apply -f /var/vcap/jobs/service-fabrik-interoperator/config/cluster.yaml
 <% end %>


### PR DESCRIPTION
* Creating Interoperator CRDs during the apiserver post-start
* Since all other processes like broker, interoperator etc. are dependent on the APIServer process, by the time these processes come up, we can ensure that the CRDs are registered.
* With that, we can remove codes to register CRDs from broker.(https://github.com/cloudfoundry-incubator/service-fabrik-broker/pull/804)