### PR TITLE
adding post-start hook for docker job

### DIFF
--- a/jobs/docker/spec
+++ b/jobs/docker/spec
@@ -11,6 +11,7 @@ templates:
   bin/cgroupfs-mount: bin/cgroupfs-mount
   bin/docker_ctl.erb: bin/docker_ctl
   bin/job_properties.sh.erb: bin/job_properties.sh
+  bin/post-start.erb: bin/post-start
   bin/lvmvd_ctl.erb: bin/lvmvd_ctl
   config/docker.cacert.erb: config/docker.cacert
   config/docker.cert.erb: config/docker.cert

--- a/jobs/docker/templates/bin/docker_ctl.erb
+++ b/jobs/docker/templates/bin/docker_ctl.erb
@@ -66,19 +66,27 @@ case $1 in
             sudo sh -c 'echo dockremap:500000:65536 >> /etc/subgid'          
         fi                                                                 
         set -e
-    fi                                                           
-
-    #create symlink from /etc/docker/key.json to /var/vcap/store/docker/key.json
+    fi     
+                                                          
+    # ensure /etc/docker exists
     if [[ ! -d /etc/docker ]] ; then
       mkdir /etc/docker
-      ln -s "${DOCKER_DAEMON_KEY_FILE_ARG}" /etc/docker/key.json
-    elif [[ ! -f /etc/docker/key.json  ]] ; then
-      ln -s "${DOCKER_DAEMON_KEY_FILE_ARG}" /etc/docker/key.json
-    else
-      link_target=$(readlink -f /etc/docker/key.json)
-      if [[ "${link_target}" != "${DOCKER_DAEMON_KEY_FILE_ARG}" ]]; then
-        mv /etc/docker/key.json /etc/docker/key.json.backup
+    fi
+    # create symlink from /etc/docker/key.json to /var/vcap/store/docker/key.json
+    if [[ -f "${DOCKER_DAEMON_KEY_FILE_ARG}" ]]; then 
+      # let docker start with key located at default /etc/docker/key.json
+      # if /var/vcap/store/docker/key.json doesn't exist. 
+      # Scratch install or new docker vm scenario
+      
+      # backup /etc/docker/key.json from previous run and symlink it to /var/vcap/store/docker/key.json
+      if [[ ! -f /etc/docker/key.json  ]] ; then
         ln -s "${DOCKER_DAEMON_KEY_FILE_ARG}" /etc/docker/key.json
+      else
+        link_target=$(readlink -f /etc/docker/key.json)
+        if [[ "${link_target}" != "${DOCKER_DAEMON_KEY_FILE_ARG}" ]]; then
+          mv /etc/docker/key.json /etc/docker/key.json.backup
+          ln -s "${DOCKER_DAEMON_KEY_FILE_ARG}" /etc/docker/key.json
+        fi
       fi
     fi
     
@@ -165,6 +173,12 @@ case $1 in
     # Unblock the port docker demon port by removing the rule
     iptables -D INPUT -p tcp --dport ${DOCKER_TCP_PORT} -j DROP
     set -e
+
+    # Ensure key file exists at /var/vcap/store/docker/key.json
+    if [[ ! -f "${DOCKER_DAEMON_KEY_FILE_ARG}" ]] && [[ -f /etc/docker/key.json ]] ; then 
+      touch "${DOCKER_DAEMON_KEY_FILE_ARG}"
+      cp /etc/docker/key.json "${DOCKER_DAEMON_KEY_FILE_ARG}"
+    fi
     ;;
 
   *)

--- a/jobs/docker/templates/bin/post-start.erb
+++ b/jobs/docker/templates/bin/post-start.erb
@@ -1,0 +1,8 @@
+#!/bin/bash 
+set -e
+
+DOCKER_DAEMON_KEY_FILE_ARG=<%= p('docker.daemon.keyfile') %>
+if [[ ! -f "${DOCKER_DAEMON_KEY_FILE_ARG}"  ]] && [[ -f /etc/docker/key.json ]] ; then
+  touch "${DOCKER_DAEMON_KEY_FILE_ARG}"
+  cp /etc/docker/key.json "${DOCKER_DAEMON_KEY_FILE_ARG}"
+fi


### PR DESCRIPTION
To maintain constant ID for docker engines in swarm, method suggested in https://github.com/moby/moby/issues/41443 is used. Also `post-start` hook is added to account for scenarios like scratch landscape setup/new docker vm in cluster.