### PR TITLE
Import the apiserver ip address when creating the kubeconfig

### DIFF
--- a/jobs/service-fabrik-apiserver/spec
+++ b/jobs/service-fabrik-apiserver/spec
@@ -47,6 +47,7 @@ properties:
     description: "CRD list to be deployed on apiserver"
   ip:
     description: IP address used for apiserver
+    default: "127.0.0.1"
   port:
     description: Port used for apiserver
     default: 9443

--- a/jobs/service-fabrik-interoperator/templates/config/cluster.yaml.erb
+++ b/jobs/service-fabrik-interoperator/templates/config/cluster.yaml.erb
@@ -6,7 +6,7 @@ apiVersion: v1
 clusters:
 - cluster:
     certificate-authority-data: "#{CA_BASE64}"
-    server: "https://127.0.0.1:#{link('service-fabrik-apiserver').p('port')}"
+    server: "https://#{link('service-fabrik-apiserver').p('ip')}:#{link('service-fabrik-apiserver').p('port')}"
   name: apiserver
 contexts:
 - context:

--- a/jobs/service-fabrik-interoperator/templates/config/kubeconfig.yaml.erb
+++ b/jobs/service-fabrik-interoperator/templates/config/kubeconfig.yaml.erb
@@ -7,7 +7,7 @@ apiVersion: v1
 clusters:
 - cluster:
     certificate-authority-data: "<%= CA_BASE64 %>"
-    server: "https://127.0.0.1:<%= link('service-fabrik-apiserver').p('port') %>"
+    server: "https://<%= link('service-fabrik-apiserver').p('ip') %>:<%= link('service-fabrik-apiserver').p('port') %>"
   name: apiserver
 contexts:
 - context:

--- a/jobs/service-fabrik-postgresqlmt-operator/templates/config/kubeconfig.yaml.erb
+++ b/jobs/service-fabrik-postgresqlmt-operator/templates/config/kubeconfig.yaml.erb
@@ -7,7 +7,7 @@ apiVersion: v1
 clusters:
 - cluster:
     certificate-authority-data: "<%= CA_BASE64 %>"
-    server: "https://127.0.0.1:<%= link('service-fabrik-apiserver').p('port') %>"
+    server: "https://<%= link('service-fabrik-apiserver').p('ip') %>:<%= link('service-fabrik-apiserver').p('port') %>"
   name: apiserver
 contexts:
 - context:

--- a/jobs/service-fabrik-serviceflow-manager/templates/config/kubeconfig.yaml.erb
+++ b/jobs/service-fabrik-serviceflow-manager/templates/config/kubeconfig.yaml.erb
@@ -7,7 +7,7 @@ apiVersion: v1
 clusters:
 - cluster:
     certificate-authority-data: "<%= CA_BASE64 %>"
-    server: "https://127.0.0.1:<%= link('service-fabrik-apiserver').p('port') %>"
+    server: "https://<%= link('service-fabrik-apiserver').p('ip') %>:<%= link('service-fabrik-apiserver').p('port') %>"
   name: apiserver
 contexts:
 - context:

--- a/jobs/webhooks/templates/config/kubeconfig.yaml.erb
+++ b/jobs/webhooks/templates/config/kubeconfig.yaml.erb
@@ -7,7 +7,7 @@ apiVersion: v1
 clusters:
 - cluster:
     certificate-authority-data: "<%= CA_BASE64 %>"
-    server: "https://127.0.0.1:<%= link('service-fabrik-apiserver').p('port') %>"
+    server: "https://<%= link('service-fabrik-apiserver').p('ip') %>:<%= link('service-fabrik-apiserver').p('port') %>"
   name: apiserver
 contexts:
 - context:


### PR DESCRIPTION
Use the imported ip address instead of hardcode localhost. This should usually not have a behavioral difference, because the exported ip address is localhost.
In our usecase we want to move/replace the apiserver, so we need to have this configurable.