### PR TITLE
Fix Yarn version to v2.4.1

### DIFF
--- a/packages/service-fabrik-broker/pre_packaging
+++ b/packages/service-fabrik-broker/pre_packaging
@@ -27,7 +27,7 @@ set -u
 
   # Install production dependencies
   npm install -g yarn
-  yarn set version berry
+  yarn set version 2.4.1
   yarn install
 
   # Precompile static files if needed

--- a/packages/service-fabrik-deployment-hooks/pre_packaging
+++ b/packages/service-fabrik-deployment-hooks/pre_packaging
@@ -27,7 +27,7 @@ set -u
 
   # Install production dependencies
   npm install -g yarn
-  yarn set version berry
+  yarn set version 2.4.1
   yarn install
 
   # Precompile static files if needed


### PR DESCRIPTION
#### What this PR does / why we need it:

The new v3.0.0 of Yarn package manager has breaking changes from previous version. The `yarn set version berry` now installs v3.x of Yarn. Fixing Yarn version as v2.4.1 until compatibility issues with v3.0.0 are resolved.

Companion of cloudfoundry-incubator/service-fabrik-broker/pull/1397
Overrides #224 